### PR TITLE
Correcting deep residual block function

### DIFF
--- a/tflearn/layers/conv.py
+++ b/tflearn/layers/conv.py
@@ -513,7 +513,7 @@ def deep_bottleneck(incoming, nb_layers, nb_filter, bottleneck_size,
     return resnet
 
 
-def deep_residual_block(incoming, nb_blocks, out_channels,
+def deep_residual_block(incoming, nb_blocks, bottleneck_size, out_channels,
                         downsample=False, downsample_strides=2,
                         activation='relu', batch_norm=True, bias=False,
                         weights_init='uniform_scaling', bias_init='zeros',
@@ -535,6 +535,8 @@ def deep_residual_block(incoming, nb_blocks, out_channels,
     Arguments:
         incoming: `Tensor`. Incoming 4-D Layer.
         nb_blocks: `int`. Number of layer blocks.
+        bottleneck_size: `int`. The number of convolutional filter of the
+            bottleneck convolutional layer.
         out_channels: `int`. The number of convolutional filters of the
             layers surrounding the bottleneck layer.
         downsample:
@@ -578,19 +580,19 @@ def deep_residual_block(incoming, nb_blocks, out_channels,
                     # accept kernel size < strides.
                     resnet = avg_pool_2d(resnet, downsample_strides,
                                          downsample_strides)
-                    resnet = conv_2d(resnet, in_channels, 1, 1, 'valid',
+                    resnet = conv_2d(resnet, bottleneck_size, 1, 1, 'valid',
                                      activation, bias, weights_init,
                                      bias_init, regularizer, weight_decay,
                                      trainable, restore)
                 else:
-                    resnet = conv_2d(resnet, in_channels, 1, 1, 'valid',
+                    resnet = conv_2d(resnet, bottleneck_size, 1, 1, 'valid',
                                      activation, bias, weights_init,
                                      bias_init, regularizer, weight_decay,
                                      trainable, restore)
                 if batch_norm:
                     resnet = tflearn.batch_normalization(resnet)
 
-                resnet = conv_2d(resnet, in_channels, 3, 1, 'same',
+                resnet = conv_2d(resnet, bottleneck_size, 3, 1, 'same',
                                  activation, bias, weights_init,
                                  bias_init, regularizer, weight_decay,
                                  trainable, restore)
@@ -612,6 +614,7 @@ def deep_residual_block(incoming, nb_blocks, out_channels,
                     
                 # Projection to new dimension
                 if in_channels != out_channels:
+                    in_channels = out_channels
                     identity = conv_2d(identity, out_channels, 1, 1, 'valid',
                                        'linear', bias, weights_init,
                                        bias_init, regularizer, weight_decay,
@@ -722,6 +725,7 @@ def shallow_residual_block(incoming, nb_blocks, out_channels,
 
                 # Projection to new dimension
                 if in_channels != out_channels:
+                    in_channels = out_channels
                     identity = conv_2d(identity, out_channels, 1, 1, 'same',
                                        'linear', bias, weights_init,
                                        bias_init, regularizer, weight_decay,


### PR DESCRIPTION
This PR addresses two issues inside residual layers:

1 - If we create a projection mapping everytime `in_channels != out_channels`, we will cause the whole residual block to contain projection mappings because in_channels is only init once before the loop (https://github.com/tflearn/tflearn/blob/master/tflearn/layers/conv.py#L568). 

![screen shot 2016-04-06 at 1 37 11 pm](https://cloud.githubusercontent.com/assets/1241240/14327867/47360826-fc02-11e5-89de-77eea6a1bd72.png).

Setting `in_channels = out_channels` after projection solves this issue and guarantees that only the first layer of the residual block contain a projection mapping:

![screen shot 2016-04-06 at 1 56 20 pm](https://cloud.githubusercontent.com/assets/1241240/14327900/66cb2338-fc02-11e5-9ef6-f9f9d4c2ce4b.png)

2 - We need to be able to set a special `bottleneck_size` for deep residual layers. Following example should highlight why:

```python
resnet =  deep_residual_block(incoming, 6, 128)
resnet =  deep_residual_block(resnet, 6, 256)
resnet =  deep_residual_block(resnet, 6, 512)
```
Because we init `in_channels` as our bottlenecks, this causes our bottlenecks to be 128 and 256 respectively. Instead we want to have something like this in the original paper :

```python
resnet =  deep_residual_block(incoming, 6, 16, 128)
resnet =  deep_residual_block(resnet, 6, 32, 256)
resnet =  deep_residual_block(resnet, 6, 64, 512)
```
