### PR TITLE
Chg SummaryWriter arg GraphDef to Graph

### DIFF
--- a/tflearn/helpers/trainer.py
+++ b/tflearn/helpers/trainer.py
@@ -192,7 +192,7 @@ class Trainer(object):
         with self.graph.as_default():
 
             self.summ_writer = tf.train.SummaryWriter(
-                self.tensorboard_dir + run_id, self.session.graph_def)
+                self.tensorboard_dir + run_id, self.session.graph)
 
             feed_dicts = to_list(feed_dicts)
             for d in feed_dicts: standarize_dict(d)


### PR DESCRIPTION
SummaryWriter argument GraphDef is deprecated in TensorFlow 0.8
See issue #37 