### PR TITLE
No longer pass batch size in output shape of conv2D transpose.

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -61,10 +61,12 @@ class TestLayers(unittest.TestCase):
         Y = [[1., 0.], [0., 1.], [1., 0.], [0., 1.]]
 
         with tf.Graph().as_default():
+            from tflearn import utils
             g = tflearn.input_data(shape=[None, 4])
             g = tflearn.reshape(g, new_shape=[-1, 2, 2, 1])
             g = tflearn.conv_2d(g, 4, 2)
             g = tflearn.conv_2d(g, 4, 1)
+            g = tflearn.conv_2d_transpose(g, 4, 2, [2, 2, 4])
             g = tflearn.max_pool_2d(g, 2)
             g = tflearn.fully_connected(g, 2, activation='softmax')
             g = tflearn.regression(g, optimizer='sgd', learning_rate=1.)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -61,7 +61,6 @@ class TestLayers(unittest.TestCase):
         Y = [[1., 0.], [0., 1.], [1., 0.], [0., 1.]]
 
         with tf.Graph().as_default():
-            from tflearn import utils
             g = tflearn.input_data(shape=[None, 4])
             g = tflearn.reshape(g, new_shape=[-1, 2, 2, 1])
             g = tflearn.conv_2d(g, 4, 2)


### PR DESCRIPTION
Gets the batch_size from the incoming tensor so it shouldn't need to be set on network creation (conv2d transpose doesn't seem to work with an undefined batch_size - correct me if I'm wrong).

Also added a conv2d transpose layer to the layers test for a quick test.

I'm not too familiar with the PR process here, so let me know if I'm doing something wrong :).