### PR TITLE
Added stronger negative init bias to highway layers

### DIFF
--- a/tflearn/layers/conv.py
+++ b/tflearn/layers/conv.py
@@ -868,7 +868,7 @@ def highway_conv_2d(incoming, nb_filter, filter_size, strides=1, padding='same',
                                  transform_gate, W_T)
 
             b_T = vs.variable(transform_gate + 'b', shape=nb_filter,
-                              initializer=tf.constant_initializer(-1),
+                              initializer=tf.constant_initializer(-3),
                               trainable=trainable, restore=restore)
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' +
                                  transform_gate, b_T)
@@ -988,7 +988,7 @@ def highway_conv_1d(incoming, nb_filter, filter_size, strides=1, padding='same',
                                  transform_gate, W_T)
 
             b_T = vs.variable(transform_gate + 'b', shape=nb_filter,
-                              initializer=tf.constant_initializer(-1),
+                              initializer=tf.constant_initializer(-3),
                               trainable=trainable, restore=restore)
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' +
                                  transform_gate, b_T)


### PR DESCRIPTION
Bias was -1, bumped to -3. As per http://arxiv.org/pdf/1505.00387.pdf in section 2.2, paragraph 2. Since TFLearn is supposed to be more hands off, I believe a stronger bias towards carry behavior would be more forgiving at the potential cost of longer train times to overcome the negative bias.