### PR TITLE
Issue 160

### DIFF
--- a/tflearn/datasets/cifar10.py
+++ b/tflearn/datasets/cifar10.py
@@ -70,12 +70,24 @@ def maybe_download(filename, source_url, work_directory):
     if not os.path.exists(filepath):
         print("Downloading CIFAR 10, Please wait...")
         filepath, _ = urllib.request.urlretrieve(source_url + filename,
-                                                 filepath)
+                                                 filepath, reporthook)
         statinfo = os.stat(filepath)
         print(('Succesfully downloaded', filename, statinfo.st_size, 'bytes.'))
         untar(filepath)
     return filepath
 
+#reporthook from stackoverflow #13881092
+def reporthook(blocknum, blocksize, totalsize):
+    readsofar = blocknum * blocksize
+    if totalsize > 0:
+        percent = readsofar * 1e2 / totalsize
+        s = "\r%5.1f%% %*d / %d" % (
+            percent, len(str(totalsize)), readsofar, totalsize)
+        sys.stderr.write(s)
+        if readsofar >= totalsize: # near the end
+            sys.stderr.write("\n")
+    else: # total size is unknown
+        sys.stderr.write("read %d\n" % (readsofar,))
 
 def untar(fname):
     if (fname.endswith("tar.gz")):

--- a/tflearn/datasets/oxflower17.py
+++ b/tflearn/datasets/oxflower17.py
@@ -44,7 +44,7 @@ def maybe_download(filename, source_url, work_directory):
         print("Downloading Oxford 17 category Flower Dataset, Please "
               "wait...")
         filepath, _ = urllib.request.urlretrieve(source_url + filename,
-                                                 filepath)
+                                                 filepath, reporthook)
         statinfo = os.stat(filepath)
         print(('Succesfully downloaded', filename, statinfo.st_size, 'bytes.'))
 
@@ -52,6 +52,18 @@ def maybe_download(filename, source_url, work_directory):
         build_class_directories(os.path.join(work_directory, 'jpg'))
     return filepath
 
+#reporthook from stackoverflow #13881092
+def reporthook(blocknum, blocksize, totalsize):
+    readsofar = blocknum * blocksize
+    if totalsize > 0:
+        percent = readsofar * 1e2 / totalsize
+        s = "\r%5.1f%% %*d / %d" % (
+            percent, len(str(totalsize)), readsofar, totalsize)
+        sys.stderr.write(s)
+        if readsofar >= totalsize: # near the end
+            sys.stderr.write("\n")
+    else: # total size is unknown
+        sys.stderr.write("read %d\n" % (readsofar,))
 
 def build_class_directories(dir):
     dir_id = 0


### PR DESCRIPTION
Because blocksize is 8192, when I add this to mnist.py, it produces erronous numbers. For cifar, oxflower, and bigger datasets in the future, I think it's worth putting.