### PR TITLE
Fixed indexing error in MNIST

### DIFF
--- a/tflearn/datasets/mnist.py
+++ b/tflearn/datasets/mnist.py
@@ -32,7 +32,7 @@ def maybe_download(filename, work_directory):
 
 def _read32(bytestream):
     dt = numpy.dtype(numpy.uint32).newbyteorder('>')
-    return numpy.frombuffer(bytestream.read(4), dtype=dt)
+    return numpy.frombuffer(bytestream.read(4), dtype=dt)[0]
 
 
 def extract_images(filename):


### PR DESCRIPTION
I tried the simple Autoencoder MNIST example, but loading MNIST failed with Numpy v1.12: the minimum example

> import tflearn.datasets.mnist as mnist
> mnist.load_data(one_hot=True)

yields the traceback

> ---------------------------------------------------------------------------
> TypeError                                 Traceback (most recent call last)
> <ipython-input-2-2e64cd0f0793> in <module>()
>       1 get_ipython().magic('pdb')
> ----> 2 mnist.load_data(one_hot=True)
> 
> /usr/local/lib/python3.4/dist-packages/tflearn/datasets/mnist.py in load_data(one_hot)
>      13 
>      14 def load_data(one_hot=False):
> ---> 15     mnist = read_data_sets("mnist/", one_hot=one_hot)
>      16     return mnist.train.images, mnist.train.labels, mnist.test.images, mnist.test.labels
>      17 
> 
> /usr/local/lib/python3.4/dist-packages/tflearn/datasets/mnist.py in read_data_sets(train_dir, fake_data, one_hot)
>     159     VALIDATION_SIZE = 5000
>     160     local_file = maybe_download(TRAIN_IMAGES, train_dir)
> --> 161     train_images = extract_images(local_file)
>     162     local_file = maybe_download(TRAIN_LABELS, train_dir)
>     163     train_labels = extract_labels(local_file, one_hot=one_hot)
> 
> /usr/local/lib/python3.4/dist-packages/tflearn/datasets/mnist.py in extract_images(filename)
>      48         rows = _read32(bytestream)
>      49         cols = _read32(bytestream)
> ---> 50         buf = bytestream.read(rows * cols * num_images)
>      51         data = numpy.frombuffer(buf, dtype=numpy.uint8)
>      52         data = data.reshape(num_images, rows, cols, 1)
> 
> /usr/lib/python3.4/gzip.py in read(self, size)
>     370 
>     371         offset = self.offset - self.extrastart
> --> 372         chunk = self.extrabuf[offset: offset + size]
>     373         self.extrasize = self.extrasize - size
>     374 
> 
> TypeError: only integer scalar arrays can be converted to a scalar index

The [reason](https://stackoverflow.com/questions/34010859/tensorflow-beginner-tutorial-read-data-sets-fails) is that for more recent versions of Numpy it is an error to treat a single-element array as a scalar for the purposes of indexing. The fix is very simple (see commit).
