### PR TITLE
Fix return_seq=True for dynamic RNN.

### DIFF
--- a/tflearn/layers/recurrent.py
+++ b/tflearn/layers/recurrent.py
@@ -80,8 +80,11 @@ def _rnn_template(incoming, cell, dropout=None, return_seq=False,
         tf.add_to_collection(tf.GraphKeys.ACTIVATIONS, outputs[-1])
 
     if dynamic:
-        outputs = tf.transpose(tf.pack(outputs), [1, 0, 2])
-        o = advanced_indexing_op(outputs, sequence_length)
+        if return_seq:
+            o = outputs
+        else:
+            outputs = tf.transpose(tf.pack(outputs), [1, 0, 2])
+            o = advanced_indexing_op(outputs, sequence_length)
     else:
         o = outputs if return_seq else outputs[-1]
 
@@ -382,8 +385,11 @@ def bidirectional_rnn(incoming, rnncell_fw, rnncell_bw, return_seq=False,
         tf.add_to_collection(tf.GraphKeys.ACTIVATIONS, outputs[-1])
 
     if dynamic:
-        outputs = tf.transpose(tf.pack(outputs), [1, 0, 2])
-        o = advanced_indexing_op(outputs, sequence_length)
+        if return_seq:
+            o = outputs
+        else:
+            outputs = tf.transpose(tf.pack(outputs), [1, 0, 2])
+            o = advanced_indexing_op(outputs, sequence_length)
     else:
         o = outputs if return_seq else outputs[-1]
 


### PR DESCRIPTION
Fixes the bug that for RNNs dynamic=True ignored the return_seq parameter and always returned just the last output.