### PR TITLE
Fix typo: Default `off_value` for `one_hot_encoding` should be zero

### DIFF
--- a/tflearn/layers/core.py
+++ b/tflearn/layers/core.py
@@ -541,7 +541,7 @@ def highway(incoming, n_units, activation='linear', transform_dropout=None,
     return inference
 
 
-def one_hot_encoding(target, n_classes, on_value=1.0, off_value=1.0,
+def one_hot_encoding(target, n_classes, on_value=1.0, off_value=0.0,
                      name="OneHotEncoding"):
     """ One Hot Encoding.
 


### PR DESCRIPTION
Pull Request to fix issue #224.

The default one hot encoding should convert integers into vectors that
contain `0`, except for a single `1` at the index that corresponds to the
integer.

The typo lead to vectors that were all `1`s instead.