### PR TITLE
Save models with better validation hit accuracy

### DIFF
--- a/tflearn/callbacks.py
+++ b/tflearn/callbacks.py
@@ -216,7 +216,6 @@ class ModelSaver(object):
         self.best_snapshot_path = best_snapshot_path
         self.snapshot_step = snapshot_step
         self.best_val_accuracy = best_val_accuracy
-        self.snapshot_step = snapshot_step
 
     def on_epoch_begin(self):
         pass

--- a/tflearn/callbacks.py
+++ b/tflearn/callbacks.py
@@ -207,13 +207,16 @@ class TermLogger(Callback):
 
 
 class ModelSaver(object):
-    def __init__(self, save_func, training_step, snapshot_path, best_snapshot_path, best_val_accuracy, snapshot_epoch):
+    def __init__(self, save_func, training_step, snapshot_path, best_snapshot_path,
+                 best_val_accuracy, snapshot_step, snapshot_epoch):
         self.save_func = save_func
         self.training_step = training_step
         self.snapshot_path = snapshot_path
         self.snapshot_epoch = snapshot_epoch
         self.best_snapshot_path = best_snapshot_path
+        self.snapshot_step = snapshot_step
         self.best_val_accuracy = best_val_accuracy
+        self.snapshot_step = snapshot_step
 
     def on_epoch_begin(self):
         pass
@@ -233,12 +236,12 @@ class ModelSaver(object):
 
     def on_batch_end(self, snapshot_model=False, best_checkpoint_path=None, val_accuracy=None):
         self.training_step += 1
-        if snapshot_model:
+        if snapshot_model & (self.snapshot_step is not None):
             self.save()
-        if not None in (best_checkpoint_path, val_accuracy, self.best_val_accuracy):
+        if None not in (best_checkpoint_path, val_accuracy, self.best_val_accuracy):
             if val_accuracy > self.best_val_accuracy:
                 self.best_val_accuracy = val_accuracy
-                self.save_best(10000 * round(val_accuracy, 4))
+                self.save_best(int(10000 * round(val_accuracy, 4)))
 
     def on_sub_batch_begin(self):
         pass

--- a/tflearn/callbacks.py
+++ b/tflearn/callbacks.py
@@ -238,7 +238,7 @@ class ModelSaver(object):
         if not None in (best_checkpoint_path, val_accuracy, self.best_val_accuracy):
             if val_accuracy > self.best_val_accuracy:
                 self.best_val_accuracy = val_accuracy
-                self.save_best(1000 * round(val_accuracy, 4))
+                self.save_best(10000 * round(val_accuracy, 4))
 
     def on_sub_batch_begin(self):
         pass

--- a/tflearn/callbacks.py
+++ b/tflearn/callbacks.py
@@ -207,11 +207,13 @@ class TermLogger(Callback):
 
 
 class ModelSaver(object):
-    def __init__(self, save_func, training_step, snapshot_path, snapshot_epoch):
+    def __init__(self, save_func, training_step, snapshot_path, best_snapshot_path, best_val_accuracy, snapshot_epoch):
         self.save_func = save_func
         self.training_step = training_step
         self.snapshot_path = snapshot_path
         self.snapshot_epoch = snapshot_epoch
+        self.best_snapshot_path = best_snapshot_path
+        self.best_val_accuracy = best_val_accuracy
 
     def on_epoch_begin(self):
         pass
@@ -229,10 +231,14 @@ class ModelSaver(object):
     def on_batch_begin(self):
         pass
 
-    def on_batch_end(self, snapshot_model=False):
+    def on_batch_end(self, snapshot_model=False, best_checkpoint_path=None, val_accuracy=None):
         self.training_step += 1
         if snapshot_model:
             self.save()
+        if not None in (best_checkpoint_path, val_accuracy, self.best_val_accuracy):
+            if val_accuracy > self.best_val_accuracy:
+                self.best_val_accuracy = val_accuracy
+                self.save_best(1000 * round(val_accuracy, 4))
 
     def on_sub_batch_begin(self):
         pass
@@ -249,3 +255,8 @@ class ModelSaver(object):
     def save(self):
         if self.snapshot_path:
             self.save_func(self.snapshot_path, self.training_step)
+
+    def save_best(self, val_accuracy):
+        if self.best_snapshot_path:
+            snapshot_path = self.best_snapshot_path + str(val_accuracy)
+            self.save_func(snapshot_path)

--- a/tflearn/helpers/trainer.py
+++ b/tflearn/helpers/trainer.py
@@ -234,6 +234,7 @@ class Trainer(object):
                                               self.checkpoint_path,
                                               self.best_checkpoint_path,
                                               self.best_val_accuracy,
+                                              snapshot_step,
                                               snapshot_epoch)
 
             for i, train_op in enumerate(self.train_ops):

--- a/tflearn/helpers/trainer.py
+++ b/tflearn/helpers/trainer.py
@@ -50,6 +50,10 @@ class Trainer(object):
         session: `Session`. A session for running ops. If None, a new one will
             be created. Note: When providing a session, variables must have been
             initialized already, otherwise an error will be raised.
+        best_val_accuracy: `float` The minimum validation accuracy that needs to be
+            achieved before a model weight's are saved to the best_checkpoint_path. This
+            allows the user to skip early saves and also set a minimum save point when continuing
+            to train a reloaded model. Default: 0.0.
 
     """
 

--- a/tflearn/helpers/trainer.py
+++ b/tflearn/helpers/trainer.py
@@ -41,6 +41,8 @@ class Trainer(object):
             ```
         checkpoint_path: `str`. Path to store model checkpoints. If None,
             no model checkpoint will be saved. Default: None.
+        best_checkpoint_path: `str`. Path to store the model when the validation rate reaches its
+            highest point of the current training session and also is above best_val_accuracy. Default: None.
         max_checkpoints: `int` or None. Maximum amount of checkpoints. If
             None, no limit. Default: None.
         keep_checkpoint_every_n_hours: `float`. Number of hours between each

--- a/tflearn/layers/estimator.py
+++ b/tflearn/layers/estimator.py
@@ -31,7 +31,7 @@ def regression(incoming, placeholder=None, optimizer='adam',
             You can retrieve that placeholder through graph key: 'TARGETS',
             or the 'placeholder' attribute of this function's returned tensor.
         optimizer: `str` (name), `Optimizer` or `function`. Optimizer to use.
-            Default: 'sgd' (Stochastic Descent Gradient).
+            Default: 'adam' (Adaptive Moment Estimation).
         loss: `str` (name) or `function`. Loss function used by this layer
             optimizer. Default: 'categorical_crossentropy'.
         metric: `str`, `Metric` or `function`. The metric to be used.

--- a/tflearn/models/dnn.py
+++ b/tflearn/models/dnn.py
@@ -27,11 +27,17 @@ class DNN(object):
             Default: "/tmp/tflearn_logs/"
         checkpoint_path: `str`. Path to store model checkpoints. If None,
             no model checkpoint will be saved. Default: None.
+        best_checkpoint_path: `str`. Path to store the model when the validation rate reaches its
+            highest point of the current training session and also is above best_val_accuracy. Default: None.
         max_checkpoints: `int` or None. Maximum amount of checkpoints. If
             None, no limit. Default: None.
         session: `Session`. A session for running ops. If None, a new one will
             be created. Note: When providing a session, variables must have been
             initialized already, otherwise an error will be raised.
+        best_val_accuracy: `float` The minimum validation accuracy that needs to be
+            achieved before a model weight's are saved to the best_checkpoint_path. This
+            allows the user to skip early saves and also set a minimum save point when continuing
+            to train a reloaded model. Default: 0.0.
 
     Attributes:
         trainer: `Trainer`. Handle model training.

--- a/tflearn/models/dnn.py
+++ b/tflearn/models/dnn.py
@@ -39,8 +39,8 @@ class DNN(object):
     """
 
     def __init__(self, network, clip_gradients=5.0, tensorboard_verbose=0,
-                 tensorboard_dir="/tmp/tflearn_logs/", checkpoint_path=None,
-                 max_checkpoints=None, session=None):
+                 tensorboard_dir="/tmp/tflearn_logs/", checkpoint_path=None, best_checkpoint_path=None,
+                 max_checkpoints=None, session=None, best_val_accuracy=0.0):
         assert isinstance(network, tf.Tensor), "'network' arg is not a Tensor!"
         self.net = network
         self.train_ops = tf.get_collection(tf.GraphKeys.TRAIN_OPS)
@@ -49,8 +49,10 @@ class DNN(object):
                                tensorboard_dir=tensorboard_dir,
                                tensorboard_verbose=tensorboard_verbose,
                                checkpoint_path=checkpoint_path,
+                               best_checkpoint_path=best_checkpoint_path,
                                max_checkpoints=max_checkpoints,
-                               session=session)
+                               session=session,
+                               best_val_accuracy=best_val_accuracy)
         self.session = self.trainer.session
 
         self.inputs = tf.get_collection(tf.GraphKeys.INPUTS)


### PR DESCRIPTION
This is in response to #165. By providing a best_checkpoint_path when creating a DNN this will only save the weights for models with hit rates higher than the highest one from the current training OR the user can specify a rate (best_val_accuracy) to the DNN and the weights will only be saved if they are both higher than all previous epochs from the current training and higher than the user specified amount. 

The weights are saved under the best_checkpoint_path and the validation accuracy percentage is appended to the model so the user knows their highest validation rate even if the logs are lost. The validation is calculated at the end of the epoch and providing a best_checkpoint_path is equivalent to saying snapshot_epoch as it will snapshot at the end of each epoch, calculate the training data, and only save the weights if they meat the aforementioned criteria. 

Definitely let me know what you guys think about this. This is very important for my current work and I'd like some implementation of this to make it in but I'm certainly up for improvements on this. 