### PR TITLE
small feature addition: allow weights to be restored to variables in other scopes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.egg-info
 build/*
 dist/*
+*~

--- a/examples/basics/weights_loading_scope.py
+++ b/examples/basics/weights_loading_scope.py
@@ -1,0 +1,212 @@
+'''
+Demonstrate that weights saved with models in one scope, can be loaded 
+into models being used in a different scope.
+
+This allows multiple models to be run, and combined models to load
+weights from separately trained models.
+'''
+
+from __future__ import division, print_function, absolute_import
+
+import re
+import tflearn
+import tensorflow as tf
+import tflearn.datasets.mnist as mnist
+
+from tflearn.layers.core import input_data, dropout, fully_connected
+from tflearn.layers.conv import conv_2d, max_pool_2d
+from tflearn.layers.normalization import local_response_normalization
+from tflearn.layers.estimator import regression
+
+#-----------------------------------------------------------------------------
+
+class Model1(object):
+    '''
+    convnet MNIST
+    '''
+    def __init__(self):
+        network = tflearn.input_data(shape=[None, 784], name="input")
+        network = self.make_core_network(network)
+        network = regression(network, optimizer='adam', learning_rate=0.01,
+                             loss='categorical_crossentropy', name='target')
+        
+        model = tflearn.DNN(network, tensorboard_verbose=0)
+        self.model = model
+
+    @staticmethod
+    def make_core_network(network):
+        network = tflearn.reshape(network, [-1, 28, 28, 1], name="reshape")
+        network = conv_2d(network, 32, 3, activation='relu', regularizer="L2")
+        network = max_pool_2d(network, 2)
+        network = local_response_normalization(network)
+        network = conv_2d(network, 64, 3, activation='relu', regularizer="L2")
+        network = max_pool_2d(network, 2)
+        network = local_response_normalization(network)
+        network = fully_connected(network, 128, activation='tanh')
+        network = dropout(network, 0.8)
+        network = fully_connected(network, 256, activation='tanh')
+        network = dropout(network, 0.8)
+        network = fully_connected(network, 10, activation='softmax')
+        return network
+
+    def train(self, X, Y, testX, testY, n_epoch=1, snapshot_step=1000):
+        # Training
+        self.model.fit({'input': X}, {'target': Y}, n_epoch=n_epoch,
+                       validation_set=({'input': testX}, {'target': testY}),
+                       snapshot_step=snapshot_step,
+                       show_metric=True, run_id='convnet_mnist')
+        
+class Model2(object):
+    '''
+    dnn MNIST
+    '''
+    def __init__(self):
+        # Building deep neural network
+        network = tflearn.input_data(shape=[None, 784], name="input")
+        network = self.make_core_network(network)
+
+        # Regression using SGD with learning rate decay and Top-3 accuracy
+        sgd = tflearn.SGD(learning_rate=0.1, lr_decay=0.96, decay_step=1000)
+        top_k = tflearn.metrics.Top_k(3)
+
+        network = tflearn.regression(network, optimizer=sgd, metric=top_k,
+                                 loss='categorical_crossentropy', name="target")
+        model = tflearn.DNN(network, tensorboard_verbose=0)
+        self.model = model
+
+    @staticmethod
+    def make_core_network(network):
+        dense1 = tflearn.fully_connected(network, 64, activation='tanh',
+                                         regularizer='L2', weight_decay=0.001, name="dense1")
+        dropout1 = tflearn.dropout(dense1, 0.8)
+        dense2 = tflearn.fully_connected(dropout1, 64, activation='tanh',
+                                         regularizer='L2', weight_decay=0.001, name="dense2")
+        dropout2 = tflearn.dropout(dense2, 0.8)
+        softmax = tflearn.fully_connected(dropout2, 10, activation='softmax', name="softmax")
+        return softmax
+
+    def train(self, X, Y, testX, testY, n_epoch=1, snapshot_step=1000):
+        # Training
+        self.model.fit(X, Y, n_epoch=n_epoch, validation_set=(testX, testY),
+                       snapshot_step=snapshot_step,
+                       show_metric=True, run_id="dense_model")
+        
+class Model12(object):
+    '''
+    Combination of two networks
+    '''
+    def __init__(self):
+        inputs = tflearn.input_data(shape=[None, 784], name="input")
+
+        with tf.variable_scope("scope1") as scope:
+            net_conv = Model1.make_core_network(inputs)	# shape (?, 10)
+        with tf.variable_scope("scope2") as scope:
+            net_dnn = Model2.make_core_network(inputs)	# shape (?, 10)
+
+        network = tf.concat(1, [net_conv, net_dnn], name="concat")	# shape (?, 20)
+        network = tflearn.fully_connected(network, 10, activation="softmax")
+        network = regression(network, optimizer='adam', learning_rate=0.01,
+                             loss='categorical_crossentropy', name='target')
+
+        self.model = tflearn.DNN(network, tensorboard_verbose=0)
+
+    def load_from_two(self, m1fn, m2fn):
+        self.model.load(m1fn, scope_for_restore="scope1", weights_only=True)
+        self.model.load(m2fn, scope_for_restore="scope2", weights_only=True, create_new_session=False)
+
+    def train(self, X, Y, testX, testY, n_epoch=1, snapshot_step=1000):
+        # Training
+        self.model.fit(X, Y, n_epoch=n_epoch, validation_set=(testX, testY),
+                       snapshot_step=snapshot_step,
+                       show_metric=True, run_id="model12")
+
+#-----------------------------------------------------------------------------
+
+X, Y, testX, testY = mnist.load_data(one_hot=True)
+
+def prepare_model1_weights_file():
+    tf.reset_default_graph()
+    m1 = Model1()
+    m1.train(X, Y, testX, testY, 2)
+    m1.model.save("model1.tfl")
+
+def prepare_model1_weights_file_in_scopeQ():
+    tf.reset_default_graph()
+    with tf.variable_scope("scopeQ") as scope:
+        m1 = Model1()
+    m1.model.fit({"scopeQ/input": X}, {"scopeQ/target": Y}, n_epoch=1, validation_set=0.1, show_metric=True, run_id="model1_scopeQ")
+    m1.model.save("model1_scopeQ.tfl")
+
+def prepare_model2_weights_file():
+    tf.reset_default_graph()
+    m2 = Model2()
+    m2.train(X, Y, testX, testY, 1)
+    m2.model.save("model2.tfl")
+
+def demonstrate_loading_weights_into_different_scope():
+    print("="*60 + " Demonstrate loading weights saved in scopeQ, into variables now in scopeA")
+    tf.reset_default_graph()
+    with tf.variable_scope("scopeA") as scope:
+        m1a = Model1()
+        print ("=" * 60 + " Trying to load model1 weights from scopeQ into scopeA")
+        m1a.model.load("model1_scopeQ.tfl", variable_name_map=("scopeA", "scopeQ"), verbose=True)
+
+def demonstrate_loading_weights_into_different_scope_using_custom_function():
+    print("="*60 + " Demonstrate loading weights saved in scopeQ, into variables now in scopeA, using custom map function")
+    tf.reset_default_graph()
+    def vname_map(ename):	# variables were saved in scopeA, but we want to load into scopeQ
+        name_in_file = ename.replace("scopeA", "scopeQ")
+        print ("%s -> %s" % (ename, name_in_file))
+        return name_in_file
+    with tf.variable_scope("scopeA") as scope:
+        m1a = Model1()
+        print ("=" * 60 + " Trying to load model1 weights from scopeQ into scopeA")
+        m1a.model.load("model1_scopeQ.tfl", variable_name_map=vname_map, verbose=True)
+
+def demonstrate_loading_two_instances_of_model1():
+    print("="*60 + " Demonstrate loading weights from model1 into two instances of model1 in scopeA and scopeB")
+    tf.reset_default_graph()
+    with tf.variable_scope("scopeA") as scope:
+        m1a = Model1()
+        print ("-" * 40 + " Trying to load model1 weights: should fail")
+        try:
+            m1a.model.load("model1.tfl", weights_only=True)
+        except Exception as err:
+            print ("Loading failed, with error as expected, because variables are in scopeA")
+            print ("error: %s" % str(err))
+        print ("-" * 40)
+
+        print ("=" * 60 + " Trying to load model1 weights: should succeed")
+        m1a.model.load("model1.tfl", scope_for_restore="scopeA", verbose=True, weights_only=True)
+
+    with tf.variable_scope("scopeB") as scope:
+        m1b = Model1()
+        m1b.model.load("model1.tfl", scope_for_restore="scopeB", verbose=True, weights_only=True)
+    print ("="*60 + " Successfully restored weights to two instances of model1, in different scopes")
+            
+def demonstrate_combined_model1_and_model2_network():
+    print("="*60 + " Demonstrate loading weights from model1 and model2 into new mashup network model12")
+    print ("-"*40 + " Creating mashup of model1 and model2 networks")
+    tf.reset_default_graph()
+    m12 = Model12()
+    print ("-"*60 + " Loading model1 and model2 weights into mashup")
+    m12.load_from_two("model1.tfl", "model2.tfl")
+    print ("-"*60 + " Training mashup")
+    m12.train(X, Y, testX, testY, 1)
+    print ("-"*60 + " Saving mashup weights")
+    m12.model.save("model12.tfl")
+    print ("-"*60 + " Done")
+
+print("="*77)
+prepare_model1_weights_file()
+prepare_model2_weights_file()
+prepare_model1_weights_file_in_scopeQ()
+print("-"*77)
+print("-"*77)
+
+demonstrate_loading_weights_into_different_scope()
+demonstrate_loading_weights_into_different_scope_using_custom_function()
+demonstrate_loading_two_instances_of_model1()
+demonstrate_combined_model1_and_model2_network()
+
+print("="*77)

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,4 @@
+test*.tflearn
+test*.tflearn.meta
+*~
+checkpoint

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,6 +28,13 @@ class TestModels(unittest.TestCase):
             m.save("test_dnn.tflearn")
             self.assertTrue(os.path.exists("test_dnn.tflearn"))
 
+        with tf.Graph().as_default():
+            input = tflearn.input_data(shape=[None])
+            linear = tflearn.single_unit(input)
+            regression = tflearn.regression(linear, optimizer='sgd', loss='mean_square',
+                                            metric='R2', learning_rate=0.01)
+            m = tflearn.DNN(regression)
+
             # Testing load method
             m.load("test_dnn.tflearn")
             res = m.predict([3.2])[0]

--- a/tests/test_models_loading_scope.py
+++ b/tests/test_models_loading_scope.py
@@ -1,0 +1,49 @@
+import tensorflow as tf
+import tflearn
+import unittest
+import os
+
+class TestModelsLoadingScope(unittest.TestCase):
+    """
+    Testing loading scope, using DNN
+    """
+
+    def test_dnn_loading_scope(self):
+
+        with tf.Graph().as_default():
+            X = [3.3,4.4,5.5,6.71,6.93,4.168,9.779,6.182,7.59,2.167,7.042,10.791,5.313,7.997,5.654,9.27,3.1]
+            Y = [1.7,2.76,2.09,3.19,1.694,1.573,3.366,2.596,2.53,1.221,2.827,3.465,1.65,2.904,2.42,2.94,1.3]
+            input = tflearn.input_data(shape=[None])
+            linear = tflearn.single_unit(input)
+            regression = tflearn.regression(linear, optimizer='sgd', loss='mean_square',
+                                            metric='R2', learning_rate=0.01)
+            m = tflearn.DNN(regression)
+            # Testing fit and predict
+            m.fit(X, Y, n_epoch=1000, show_metric=True, snapshot_epoch=False)
+            res = m.predict([3.2])[0]
+            self.assertGreater(res, 1.3, "DNN test (linear regression) failed! with score: " + str(res) + " expected > 1.3")
+            self.assertLess(res, 1.8, "DNN test (linear regression) failed! with score: " + str(res) + " expected < 1.8")
+
+            # Testing save method
+            m.save("test_dnn.tflearn")
+            self.assertTrue(os.path.exists("test_dnn.tflearn"))
+
+        # Testing loading, with change of variable scope (saved with no scope, now loading into scopeA)
+        with tf.Graph().as_default():	# start with clear graph
+            with tf.variable_scope("scopeA") as scope:
+                input = tflearn.input_data(shape=[None])
+                linear = tflearn.single_unit(input)
+                regression = tflearn.regression(linear, optimizer='sgd', loss='mean_square',
+                                                metric='R2', learning_rate=0.01)
+                m = tflearn.DNN(regression)
+                def try_load():
+                    m.load("test_dnn.tflearn")
+                self.assertRaises(tf.errors.NotFoundError, try_load)	# fails, since names in file don't have "scopeA"
+
+                m.load("test_dnn.tflearn", variable_name_map=("scopeA/", ""))	# succeeds, because variable names are rewritten
+                res = m.predict([3.2])[0]
+                self.assertGreater(res, 1.3, "DNN test (linear regression) failed after loading model! score: " + str(res) + " expected > 1.3")
+                self.assertLess(res, 1.8, "DNN test (linear regression) failed after loading model! score: " + str(res) + " expected < 1.8")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tflearn/models/dnn.py
+++ b/tflearn/models/dnn.py
@@ -226,7 +226,7 @@ class DNN(object):
         #with self.graph.as_default():
         self.trainer.save(model_file)
 
-    def load(self, model_file, weights_only=False):
+    def load(self, model_file, weights_only=False, **optargs):
         """ Load.
 
         Restore model weights.
@@ -237,8 +237,12 @@ class DNN(object):
                 and not intermediate variable, such as step counter, moving
                 averages...). Note that if you are using batch normalization,
                 averages will not be restored as well.
+            optargs: optional extra arguments for trainer.restore (see helpers/trainer.py)
+                     These optional arguments may be used to limit the scope of
+                     variables restored, and to control whether a new session is 
+                     created for the restored variables.
         """
-        self.trainer.restore(model_file, weights_only)
+        self.trainer.restore(model_file, weights_only, **optargs)
         self.session = self.trainer.session
         self.predictor = Evaluator([self.net],
                                    session=self.session,

--- a/tflearn/models/generator.py
+++ b/tflearn/models/generator.py
@@ -240,16 +240,20 @@ class SequenceGenerator(object):
         """
         self.trainer.save(model_file)
 
-    def load(self, model_file):
+    def load(self, model_file, **optargs):
         """ Load.
 
         Restore model weights.
 
         Arguments:
             model_file: `str`. Model path.
+            optargs: optional extra arguments for trainer.restore (see helpers/trainer.py)
+                     These optional arguments may be used to limit the scope of
+                     variables restored, and to control whether a new session is 
+                     created for the restored variables.
 
         """
-        self.trainer.restore(model_file)
+        self.trainer.restore(model_file, **optargs)
         self.session = self.trainer.session
         self.predictor = Evaluator([self.net],
                                    session=self.session,


### PR DESCRIPTION
When using multiple models, or combining pre-trained models to create a new model, a common desire is to be able to restore saved weights, despite variables being in a different scope.

This PR provides such a capability, by modifying trainer.restore to allow a mapping to be specified between existing variable names, and names used in the stored weights file.  For simplicity, `scope_for_restore` may be provided, specifying the scope to be used for the newly restored variable names.  This captures a common case, wherein the stored weights (stored with no explicit scope) need to be brought into a specific scope.  

For slightly more complex cases, `variable_name_map` may be provided, as a `(pattern, replacement)` regexp pair; this allows, for example, scopes to be renamed, e.g. from `scopeA` to `scopeB`.

And in the most general case, `variable_name_map` may be given as a function, which takes an existing variable name as an argument, and returns the name to use from the stored weights file.  Return values of `None` indicate variables which should be disregarded in the loading process.  This is useful, for example, when replacing fully connected layers with equivalent fully convolutional networks,  which use the same weights and biases as the original fully connected layers.

Also, `create_new_session` may be set to `False`, to inhibit the creation of a new session during weights loading.  This allows multiple weight files to be loaded, with an initialization happening only before the first load, for example, so that two or more models can be combined to create a new combined network graph, with weights restored from the component models.

Examples and unit tests are provided.  Also, test_models.py is strengthened, such that the model.load test actually does depend on what is loaded (before, it would have succeeded if `m.load` were a nop).