### PR TITLE
Allow load_data to load MNIST in other directory

### DIFF
--- a/tflearn/datasets/mnist.py
+++ b/tflearn/datasets/mnist.py
@@ -11,8 +11,8 @@ import numpy
 SOURCE_URL = 'http://yann.lecun.com/exdb/mnist/'
 
 
-def load_data(one_hot=False):
-    mnist = read_data_sets("mnist/", one_hot=one_hot)
+def load_data(data_dir="mnist/", one_hot=False):
+    mnist = read_data_sets(data_dir, one_hot=one_hot)
     return mnist.train.images, mnist.train.labels, mnist.test.images, mnist.test.labels
 
 


### PR DESCRIPTION
Add a keyword argument "data_dir" to "load_data" function