### PR TITLE
restore session config

### DIFF
--- a/tflearn/helpers/trainer.py
+++ b/tflearn/helpers/trainer.py
@@ -419,7 +419,11 @@ class Trainer(object):
         """
         if create_new_session:
             self.close_session()
-            self.session = tf.Session()
+            config = None
+            tflearn_conf = tf.get_collection(tf.GraphKeys.GRAPH_CONFIG)
+            if tflearn_conf:
+                config = tflearn_conf[0]
+            self.session = tf.Session(config=config)
             self.session.run(tf.initialize_all_variables())
 
         if scope_for_restore is not None:	# allow variables to be restored into a different scope


### PR DESCRIPTION
If I choose gpu 1 and restore from a model file, a bug comes out:

`tensorflow.python.framework.errors.InvalidArgumentError: Cannot assign a device to node 'save_3/Const': Could not satisfy explicit device specification '/device:GPU:1' because no supported kernel for GPU devices is available.`

the reason is that session is re-created without config