### PR TITLE
Add global max pooling layer and an example of CNN for text classification

### DIFF
--- a/examples/nlp/cnn_sentence_classification.py
+++ b/examples/nlp/cnn_sentence_classification.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""
+Simple example using convolutional neural network to classify IMDB
+sentiment dataset.
+
+References:
+    - Andrew L. Maas, Raymond E. Daly, Peter T. Pham, Dan Huang, Andrew Y. Ng,
+    and Christopher Potts. (2011). Learning Word Vectors for Sentiment
+    Analysis. The 49th Annual Meeting of the Association for Computational
+    Linguistics (ACL 2011).
+    - Kim Y. Convolutional Neural Networks for Sentence Classification[C]. 
+    Empirical Methods in Natural Language Processing, 2014.
+
+Links:
+    - http://ai.stanford.edu/~amaas/data/sentiment/
+    - http://emnlp2014.org/papers/pdf/EMNLP2014181.pdf
+
+"""
+from __future__ import division, print_function, absolute_import
+
+import tensorflow as tf
+import tflearn
+from tflearn.layers.core import input_data, dropout, fully_connected
+from tflearn.layers.conv import conv_1d, max_pool_1d, global_max_pool
+from tflearn.layers.merge_ops import merge
+from tflearn.layers.estimator import regression
+from tflearn.data_utils import to_categorical, pad_sequences
+from tflearn.datasets import imdb
+
+# IMDB Dataset loading
+train, test, _ = imdb.load_data(path='imdb.pkl', n_words=10000,
+                                valid_portion=0.1)
+trainX, trainY = train
+testX, testY = test
+
+# Data preprocessing
+# Sequence padding
+trainX = pad_sequences(trainX, maxlen=100, value=0.)
+testX = pad_sequences(testX, maxlen=100, value=0.)
+# Converting labels to binary vectors
+trainY = to_categorical(trainY, nb_classes=2)
+testY = to_categorical(testY, nb_classes=2)
+
+# Building convolutional network
+network = input_data(shape=[None, 100], name='input')
+network = tflearn.embedding(network, input_dim=10000, output_dim=128)
+branch1 = conv_1d(network, 128, 3, padding='valid', activation='relu', regularizer="L2")
+branch2 = conv_1d(network, 128, 4, padding='valid', activation='relu', regularizer="L2")
+branch3 = conv_1d(network, 128, 5, padding='valid', activation='relu', regularizer="L2")
+network = merge([branch1, branch2, branch3], mode='concat', axis=1)
+network = tf.expand_dims(network, 2)
+network = global_max_pool(network)
+network = dropout(network, 0.5)
+network = fully_connected(network, 2, activation='softmax')
+network = regression(network, optimizer='adam', learning_rate=0.001,
+                     loss='categorical_crossentropy', name='target')
+# Training
+model = tflearn.DNN(network, tensorboard_verbose=0)
+model.fit(trainX, trainY, n_epoch = 5, shuffle=True, validation_set=(testX, testY), show_metric=True, batch_size=32)

--- a/tflearn/layers/conv.py
+++ b/tflearn/layers/conv.py
@@ -878,6 +878,32 @@ def avg_pool_3d(incoming, kernel_size, strides=None, padding='same',
     return inference
 
 
+def global_max_pool(incoming, name="GlobalMaxPool"):
+    """ Global Max Pooling.
+
+    Input:
+        4-D Tensor [batch, height, width, in_channels].
+
+    Output:
+        2-D Tensor [batch, pooled dim]
+
+    Arguments:
+        incoming: `Tensor`. Incoming 4-D Tensor.
+        name: A name for this layer (optional). Default: 'GlobalMaxPool'.
+
+    """
+    input_shape = utils.get_incoming_shape(incoming)
+    assert len(input_shape) == 4, "Incoming Tensor shape must be 4-D"
+
+    with tf.name_scope(name):
+        inference = tf.reduce_max(incoming, [1, 2])
+
+    # Track output tensor.
+    tf.add_to_collection(tf.GraphKeys.LAYER_TENSOR + '/' + name, inference)
+
+    return inference
+
+
 def global_avg_pool(incoming, name="GlobalAvgPool"):
     """ Global Average Pooling.
 


### PR DESCRIPTION
1. add global max pooling layer, which is already supported by Caffe and is widely used, such as CNN for text classification [1].
2. add an example of cnn for sentence classification [1] on IMDB sentiment dataset [2], which can achieve a result similar to LSTM ( val_acc: 82% ).

**Reference**
[1] Kim Y. Convolutional Neural Networks for Sentence Classification[C]. Empirical Methods in Natural Language Processing, 2014.
[2] http://ai.stanford.edu/~amaas/data/sentiment/