### PR TITLE
New feature: validation monitors

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -2,3 +2,4 @@ test*.tflearn
 test*.tflearn.meta
 *~
 checkpoint
+mnist

--- a/tests/test_validation_monitors.py
+++ b/tests/test_validation_monitors.py
@@ -1,0 +1,75 @@
+from __future__ import division, print_function, absolute_import
+
+import tensorflow as tf
+import tflearn
+import unittest
+import os
+
+from tflearn.layers.core import input_data, dropout, fully_connected
+from tflearn.layers.conv import conv_2d, max_pool_2d
+from tflearn.layers.normalization import local_response_normalization
+from tflearn.layers.estimator import regression
+
+class TestValidationMonitors(unittest.TestCase):
+    """
+    Testing Validation Monitors
+    """
+
+    def test_vm1(self):
+
+        # Data loading and preprocessing
+        import tflearn.datasets.mnist as mnist
+        X, Y, testX, testY = mnist.load_data(one_hot=True)
+        X = X.reshape([-1, 28, 28, 1])
+        testX = testX.reshape([-1, 28, 28, 1])
+        X = X[:10, :, :, :]
+        Y = Y[:10, :]
+        
+        # Building convolutional network
+        network = input_data(shape=[None, 28, 28, 1], name='input')
+        network = conv_2d(network, 32, 3, activation='relu', regularizer="L2")
+        network = max_pool_2d(network, 2)
+        network = local_response_normalization(network)
+        network = conv_2d(network, 64, 3, activation='relu', regularizer="L2")
+        network = max_pool_2d(network, 2)
+        network = local_response_normalization(network)
+        network = fully_connected(network, 128, activation='tanh')
+        network = dropout(network, 0.8)
+        network = fully_connected(network, 256, activation='tanh')
+        network = dropout(network, 0.8)
+        with tf.name_scope('CustomMonitor'):
+            test_var = tf.reduce_sum(tf.cast(network, tf.float32), name="test_var")
+            test_const = tf.constant(32.0, name="custom_constant")
+        print ("network=%s, test_var=%s" % (network, test_var))
+        network = fully_connected(network, 10, activation='softmax')
+        network = regression(network, optimizer='adam', learning_rate=0.01,
+                             loss='categorical_crossentropy', name='target', validation_monitors=[test_var, test_const])
+        
+        # Training
+        model = tflearn.DNN(network, tensorboard_verbose=3)
+        model.fit({'input': X}, {'target': Y}, n_epoch=1,
+                   validation_set=({'input': testX}, {'target': testY}),
+                   snapshot_step=10, show_metric=True, run_id='convnet_mnist')
+        
+        # check for validation monitor variables
+        ats = tf.get_collection("Adam_testing_summaries")
+        print ("ats=%s" % ats)
+        self.assertTrue(len(ats)==4)	# [loss, test_var, test_const, accuracy]
+        
+        session = model.session
+        print ("session=%s" % session)
+        trainer = model.trainer
+        print ("train_ops = %s" % trainer.train_ops)
+        top = trainer.train_ops[0]
+        vmtset = top.validation_monitors_T
+        print ("validation_monitors_T = %s" % vmtset)
+        with model.session.as_default():
+            ats_var_val = tflearn.variables.get_value(vmtset[0])
+            ats_const_val = tflearn.variables.get_value(vmtset[1])
+        print ("summary values: var=%s, const=%s" % (ats_var_val, ats_const_val))
+        self.assertTrue(ats_const_val==32)
+
+        # TBD: parse the recorded tensorboard events and ensure the validation monitor variables show up there
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tflearn/helpers/trainer.py
+++ b/tflearn/helpers/trainer.py
@@ -509,17 +509,12 @@ class TrainOp(object):
             provided, it will be created. Early defining the step tensor
             might be useful for network creation, such as for learning rate
             decay.
-        input_vars: list of `Variable`. The input data for this training op
-            to be transformed by data augmentation. Default:
-            tf.GraphKeys.INPUTS collection. (optional) Only necessary when
-            using data augmentation.
-        data_preprocessing: A `DataPreprocessing` subclass object to manage
-            real-time data pre-processing when training and predicting (such
-            as zero center data, std normalization...).
-        data_augmentation: `DataAugmentation`. A `DataAugmentation` subclass
-            object to manage real-time data augmentation while training (
-            such as random image crop, random image flip, random sequence
-            reverse...).
+        validation_monitors: `list` of `Tensor` objects.  List of variables
+            to compute during validation, which are also used to produce
+            summaries for output to TensorBoard.  For example, this can be
+            used to periodically record a confusion matrix or AUC metric, 
+            during training.  Each variable should have rank 1, i.e. 
+            shape [None].
         name: `str`. A name for this class (optional).
         graph: `tf.Graph`. Tensorflow Graph to use for training. Default:
             default tf graph.
@@ -528,7 +523,7 @@ class TrainOp(object):
 
     def __init__(self, loss, optimizer, metric=None, batch_size=64, ema=0.,
                  trainable_vars=None, shuffle=True, step_tensor=None,
-                 name=None, graph=None):
+                 validation_monitors=None, name=None, graph=None):
         self.graph = tf.get_default_graph()
         if graph:
             self.graph = graph
@@ -543,6 +538,9 @@ class TrainOp(object):
         self.metric_summ_name = ""
         if metric is not None:
             self.metric_summ_name = metric.name.split('/')[0]
+        if isinstance(validation_monitors, tf.Tensor):
+            validation_monitors = [validation_monitors]
+        self.validation_monitors = validation_monitors or []
         self.grad = None
         self.apply_grad = None
         self.summ_op = None
@@ -610,6 +608,7 @@ class TrainOp(object):
         # each model evaluation (by batch). For visualization in Tensorboard.
         self.val_loss_T = tf.Variable(0., name='val_loss', trainable=False)
         self.val_acc_T = tf.Variable(0., name='val_acc', trainable=False)
+        self.validation_monitors_T = [tf.Variable(0., name='%s_T' % v.name.rsplit(':', 1)[0], trainable=False) for v in self.validation_monitors]
 
         # Creating the accuracy moving average, for better visualization.
         if self.metric is not None:
@@ -782,20 +781,22 @@ class TrainOp(object):
         if snapshot and self.val_feed_dict:
             tflearn.is_training(False, session=self.session)
             # Evaluation returns the mean over all batches.
-            eval_ops = [self.loss]
+            eval_ops = [self.loss] + self.validation_monitors	# compute loss as well as any extra validation monotor tensors
             if show_metric and self.metric is not None:
                 eval_ops.append(self.metric)
             e = evaluate_flow(self.session, eval_ops, self.test_dflow)
             self.val_loss = e[0]
+            self.validation_monitor_values = e[1:-1]
             if show_metric and self.metric is not None:
-                self.val_acc = e[1]
+                self.val_acc = e[-1]
 
             # Set evaluation results to variables, to be summarized.
+            update_val_op = [tf.assign(self.val_loss_T, self.val_loss)]
             if show_metric:
-                update_val_op = [tf.assign(self.val_loss_T, self.val_loss),
-                                 tf.assign(self.val_acc_T, self.val_acc)]
-            else:
-                update_val_op = tf.assign(self.val_loss_T, self.val_loss)
+                update_val_op.append(tf.assign(self.val_acc_T, self.val_acc))
+            if self.validation_monitors:
+                for vmt, vm in zip(self.validation_monitors_T, self.validation_monitor_values):
+                    update_val_op.append(tf.assign(vmt, vm))
             self.session.run(update_val_op)
 
             # Run summary operation.
@@ -871,6 +872,14 @@ class TrainOp(object):
                 self.val_summary_op = summarize(self.val_acc_T, "scalar",
                                                 acc_val_name,
                                                 te_summ_collection)
+            if self.validation_monitors:
+                # add summaries of additional validation monitor variables
+                for vm_op in self.validation_monitors_T:
+                    vm_name = "- " + vm_op.name + "/" + self.scope_name + "/Validation"
+                    vm_name = check_scope_path(vm_name)
+                    self.val_summary_op = summarize(vm_op, "scalar",
+                                                    vm_name,
+                                                    te_summ_collection)
 
 
 def duplicate_identical_ops(ops):

--- a/tflearn/layers/estimator.py
+++ b/tflearn/layers/estimator.py
@@ -15,7 +15,8 @@ def regression(incoming, placeholder=None, optimizer='adam',
                loss='categorical_crossentropy', metric='default',
                learning_rate=0.001, dtype=tf.float32, batch_size=64,
                shuffle_batches=True, to_one_hot=False, n_classes=None,
-               trainable_vars=None, restore=True, op_name=None, name=None):
+               trainable_vars=None, restore=True, op_name=None, 
+               validation_monitors=None, name=None):
     """ Regression.
 
     The regression layer is used in TFLearn to apply a regression (linear or
@@ -74,6 +75,12 @@ def regression(incoming, placeholder=None, optimizer='adam',
             pre-trained model.
         op_name: A name for this layer optimizer (optional).
             Default: optimizer op name.
+        validation_monitors: `list` of `Tensor` objects.  List of variables
+            to compute during validation, which are also used to produce
+            summaries for output to TensorBoard.  For example, this can be
+            used to periodically record a confusion matrix or AUC metric, 
+            during training.  Each variable should have rank 1, i.e. 
+            shape [None].
         name: A name for this layer's placeholder scope.
 
     Attributes:
@@ -181,6 +188,7 @@ def regression(incoming, placeholder=None, optimizer='adam',
                     batch_size=batch_size,
                     shuffle=shuffle_batches,
                     step_tensor=step_tensor,
+                    validation_monitors=validation_monitors,
                     name=op_name)
 
     tf.add_to_collection(tf.GraphKeys.TRAIN_OPS, tr_op)


### PR DESCRIPTION
It is useful to be able to periodically monitor various variables during training, e.g. confusion matrix entries or AUC metrics.  This PR makes such monitoring possible, by adding a `validation_monitors` argument to `estimator.regression`; this argument takes a list of `Tensor` variables, and passes them to the `trainer`, where they are evaluated each time a validation step happens.  The evaluation results are then summarized, and saved for tensorboard visualization, e.g.:

![image](https://cloud.githubusercontent.com/assets/1590761/17983953/2a3b8684-6add-11e6-9be9-a261cc0861ba.png)

when `validation_monitors` is set with these variables:

![image](https://cloud.githubusercontent.com/assets/1590761/17983994/6c27b1ee-6add-11e6-8669-481d8149c489.png)

with a call to `regression` like this:

![image](https://cloud.githubusercontent.com/assets/1590761/17984012/84da7244-6add-11e6-8318-b3946e504999.png)

Unit test included.
