### PR TITLE
Small bugfixes feed dict and placeholder

### DIFF
--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -98,5 +98,53 @@ class TestLayers(unittest.TestCase):
             m.fit(X, Y, n_epoch=300, snapshot_epoch=False)
             self.assertGreater(m.predict([[5, 9, 11, 1]])[0][1], 0.9)
 
+    def test_regression_placeholder(self):
+        '''
+        Check that regression does not duplicate placeholders
+        '''
+
+        with tf.Graph().as_default():
+
+            g = tflearn.input_data(shape=[None, 2])
+            g_nand = tflearn.fully_connected(g, 1, activation='linear')
+            with tf.name_scope("Y"):
+                Y_in = tf.placeholder(shape=[None, 1], dtype=tf.float32, name="Y")
+            tflearn.regression(g_nand, optimizer='sgd',
+                               placeholder=Y_in,
+                               learning_rate=2.,
+                               loss='binary_crossentropy', 
+                               op_name="regression1",
+                               name="Y")
+            # for this test, just use the same default trainable_vars
+            # in practice, this should be different for the two regressions
+            tflearn.regression(g_nand, optimizer='adam',
+                               placeholder=Y_in,
+                               learning_rate=2.,
+                               loss='binary_crossentropy', 
+                               op_name="regression2",
+                               name="Y")
+
+            self.assertEqual(len(tf.get_collection(tf.GraphKeys.TARGETS)), 1)
+
+    def test_feed_dict_no_None(self):
+
+        X = [[0., 0., 0., 0.], [1., 1., 1., 1.], [0., 0., 1., 0.], [1., 1., 1., 0.]]
+        Y = [[1., 0.], [0., 1.], [1., 0.], [0., 1.]]
+
+        with tf.Graph().as_default():
+            g = tflearn.input_data(shape=[None, 4], name="X_in")
+            g = tflearn.reshape(g, new_shape=[-1, 2, 2, 1])
+            g = tflearn.conv_2d(g, 4, 2)
+            g = tflearn.conv_2d(g, 4, 1)
+            g = tflearn.max_pool_2d(g, 2)
+            g = tflearn.fully_connected(g, 2, activation='softmax')
+            g = tflearn.regression(g, optimizer='sgd', learning_rate=1.)
+
+            m = tflearn.DNN(g)
+
+            def do_fit():
+                m.fit({"X_in": X, 'non_existent': X}, Y, n_epoch=30, snapshot_epoch=False)
+            self.assertRaisesRegexp(Exception, "Feed dict asks for variable named 'non_existent' but no such variable is known to exist", do_fit)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tflearn/layers/estimator.py
+++ b/tflearn/layers/estimator.py
@@ -96,7 +96,8 @@ def regression(incoming, placeholder=None, optimizer='adam',
             p_shape = [None] if to_one_hot else input_shape
             placeholder = tf.placeholder(shape=p_shape, dtype=dtype, name="Y")
 
-    tf.add_to_collection(tf.GraphKeys.TARGETS, placeholder)
+    if placeholder not in tf.get_collection(tf.GraphKeys.TARGETS):
+        tf.add_to_collection(tf.GraphKeys.TARGETS, placeholder)
 
     if to_one_hot:
         if n_classes is None:

--- a/tflearn/utils.py
+++ b/tflearn/utils.py
@@ -294,7 +294,11 @@ def feed_dict_builder(X, Y, net_inputs, net_targets):
                 if isinstance(key, tf.Tensor):
                     continue
                 else: # Else retrieve placeholder with its name
-                    feed_dict[vs.get_inputs_placeholder_by_name(key)] = val
+                    var = vs.get_inputs_placeholder_by_name(key)
+                    if var is None:
+                        raise Exception("Feed dict asks for variable named '%s' but no "
+                                        "such variable is known to exist" % key)
+                    feed_dict[var] = val
 
     if not (is_none(Y) or is_none(net_targets)):
         if not isinstance(Y, dict):
@@ -327,7 +331,11 @@ def feed_dict_builder(X, Y, net_inputs, net_targets):
                 if isinstance(key, tf.Tensor):
                     continue
                 else: # Else retrieve placeholder with its name
-                    feed_dict[vs.get_targets_placeholder_by_name(key)] = val
+                    var = vs.get_targets_placeholder_by_name(key)
+                    if var is None:
+                        raise Exception("Feed dict asks for variable named '%s' but no "
+                                        "such variable is known to exist" % key)
+                    feed_dict[var] = val
 
     return feed_dict
 


### PR DESCRIPTION
This PR provides two small bugfixes:

1. When multiple regressions are instantiated using the same placeholder variable, the placeholder should only be added once to the `TARGETS` graph.

2. When `feed_dict` is specified with a non-existent variable, a meaningful error should be raised, instead of failing later in the trainer with `Cannot interpret feed_dict key as Tensor: Can not convert a NoneType into a Tensor.`

Unit tests included.

(note that tests in `test_layers.py` test sometimes fail, when the SGD doesn't converge, randomly)