### PR TITLE
add binary_accuracy and validation_batch_size

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -9,19 +9,44 @@ class TestMetrics(unittest.TestCase):
     Testing metric functions from tflearn/metrics
     """
 
-    def test_accuracy(self):
-        input_data = tf.placeholder(shape=[None, 1], dtype=tf.float32)
-        y_true = tf.placeholder(shape=[None, 1], dtype=tf.float32)
-        ba = tflearn.metrics.binary_accuracy()
-        ba.build(input_data, y_true)
-        acc_op = ba.tensor
+    def test_binary_accuracy(self):
+        with tf.Graph().as_default():
+            input_data = tf.placeholder(shape=[None, 1], dtype=tf.float32)
+            y_true = tf.placeholder(shape=[None, 1], dtype=tf.float32)
+            ba = tflearn.metrics.accuracy()
+            ba.build(input_data, y_true)
+            acc_op = ba.tensor
+    
+            X = np.array([1,-1,1,1,-1,-1]).reshape([-1, 1])
+            Y = np.array([1,0,1,0,0,1]).reshape([-1, 1])
+            with tf.Session() as sess:
+                binary_accuracy = sess.run(acc_op, feed_dict={input_data: X, y_true: Y})
+                print ("binary_accuracy = %s" % binary_accuracy)
+            self.assertEqual(acc_op.m_name, "binary_acc")
+            self.assertLess(abs(binary_accuracy-4.0/6), 0.0001)
 
-        X = np.array([1,0,1,1,0,0]).reshape([-1, 1])
-        Y = np.array([1,0,1,0,0,1]).reshape([-1, 1])
-        with tf.Session() as sess:
-            binary_accuracy = sess.run(acc_op, feed_dict={input_data: X, y_true: Y})
-            print ("binary_accuracy = %s" % binary_accuracy)
-        self.assertTrue(abs(binary_accuracy-4.0/6)< 0.0001)
+    def test_categorical_accuracy(self):
+        with tf.Graph().as_default():
+            input_data = tf.placeholder(shape=[None, 2], dtype=tf.float32)
+            y_true = tf.placeholder(shape=[None, 2], dtype=tf.float32)
+            ba = tflearn.metrics.accuracy()
+            ba.build(input_data, y_true)
+            acc_op = ba.tensor
+    
+            X = np.array([1,-1, -1, 1, 0.5, 0]).reshape([-1, 2])
+            Y = np.array([1, 0,  0, 1, 0,   1]).reshape([-1, 2])
+            with tf.Session() as sess:
+                accuracy = sess.run(acc_op, feed_dict={input_data: X, y_true: Y})
+                print ("categorical accuracy = %s" % accuracy)
+            self.assertEqual(acc_op.m_name, "acc")
+            self.assertLess(abs(accuracy - 2.0/3), 0.0001)
+
+            X = np.array([1,-1, -1, 1, 0.5, 0]).reshape([-1, 2])
+            Y = np.array([1, 0,  0, 1, 1,   0]).reshape([-1, 2])
+            with tf.Session() as sess:
+                accuracy = sess.run(acc_op, feed_dict={input_data: X, y_true: Y})
+                print ("categorical accuracy = %s" % accuracy)
+            self.assertEqual(accuracy, 1.0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,27 @@
+import tflearn
+import unittest
+
+import numpy as np
+import tensorflow as tf
+
+class TestMetrics(unittest.TestCase):
+    """
+    Testing metric functions from tflearn/metrics
+    """
+
+    def test_accuracy(self):
+        input_data = tf.placeholder(shape=[None, 1], dtype=tf.float32)
+        y_true = tf.placeholder(shape=[None, 1], dtype=tf.float32)
+        ba = tflearn.metrics.binary_accuracy()
+        ba.build(input_data, y_true)
+        acc_op = ba.tensor
+
+        X = np.array([1,0,1,1,0,0]).reshape([-1, 1])
+        Y = np.array([1,0,1,0,0,1]).reshape([-1, 1])
+        with tf.Session() as sess:
+            binary_accuracy = sess.run(acc_op, feed_dict={input_data: X, y_true: Y})
+            print ("binary_accuracy = %s" % binary_accuracy)
+        self.assertTrue(abs(binary_accuracy-4.0/6)< 0.0001)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validation_monitors.py
+++ b/tests/test_validation_monitors.py
@@ -17,70 +17,116 @@ class TestValidationMonitors(unittest.TestCase):
 
     def test_vm1(self):
 
-        # Data loading and preprocessing
-        import tflearn.datasets.mnist as mnist
-        X, Y, testX, testY = mnist.load_data(one_hot=True)
-        X = X.reshape([-1, 28, 28, 1])
-        testX = testX.reshape([-1, 28, 28, 1])
-        X = X[:10, :, :, :]
-        Y = Y[:10, :]
-        
-        # Building convolutional network
-        network = input_data(shape=[None, 28, 28, 1], name='input')
-        network = conv_2d(network, 32, 3, activation='relu', regularizer="L2")
-        network = max_pool_2d(network, 2)
-        network = local_response_normalization(network)
-        network = conv_2d(network, 64, 3, activation='relu', regularizer="L2")
-        network = max_pool_2d(network, 2)
-        network = local_response_normalization(network)
-        network = fully_connected(network, 128, activation='tanh')
-        network = dropout(network, 0.8)
-        network = fully_connected(network, 256, activation='tanh')
-        network = dropout(network, 0.8)
+        with tf.Graph().as_default():
+            # Data loading and preprocessing
+            import tflearn.datasets.mnist as mnist
+            X, Y, testX, testY = mnist.load_data(one_hot=True)
+            X = X.reshape([-1, 28, 28, 1])
+            testX = testX.reshape([-1, 28, 28, 1])
+            X = X[:10, :, :, :]
+            Y = Y[:10, :]
+            
+            # Building convolutional network
+            network = input_data(shape=[None, 28, 28, 1], name='input')
+            network = conv_2d(network, 32, 3, activation='relu', regularizer="L2")
+            network = max_pool_2d(network, 2)
+            network = local_response_normalization(network)
+            network = conv_2d(network, 64, 3, activation='relu', regularizer="L2")
+            network = max_pool_2d(network, 2)
+            network = local_response_normalization(network)
+            network = fully_connected(network, 128, activation='tanh')
+            network = dropout(network, 0.8)
+            network = fully_connected(network, 256, activation='tanh')
+            network = dropout(network, 0.8)
+    
+            # construct two varaibles to add as additional "valiation monitors"
+            # these varaibles are evaluated each time validation happens (eg at a snapshot)
+            # and the results are summarized and output to the tensorboard events file,
+            # together with the accuracy and loss plots.
+            #
+            # Here, we generate a dummy variable given by the sum over the current
+            # network tensor, and a constant variable.  In practice, the validation
+            # monitor may present useful information, like confusion matrix
+            # entries, or an AUC metric.
+            with tf.name_scope('CustomMonitor'):
+                test_var = tf.reduce_sum(tf.cast(network, tf.float32), name="test_var")
+                test_const = tf.constant(32.0, name="custom_constant")
+    
+            print ("network=%s, test_var=%s" % (network, test_var))
+            network = fully_connected(network, 10, activation='softmax')
+            network = regression(network, optimizer='adam', learning_rate=0.01,
+                                 loss='categorical_crossentropy', name='target', validation_monitors=[test_var, test_const])
+            
+            # Training
+            model = tflearn.DNN(network, tensorboard_verbose=3)
+            model.fit({'input': X}, {'target': Y}, n_epoch=1,
+                       validation_set=({'input': testX}, {'target': testY}),
+                       snapshot_step=10, show_metric=True, run_id='convnet_mnist')
+            
+            # check for validation monitor variables
+            ats = tf.get_collection("Adam_testing_summaries")
+            print ("ats=%s" % ats)
+            self.assertTrue(len(ats)==4)	# should be four variables being summarized: [loss, test_var, test_const, accuracy]
+            
+            session = model.session
+            print ("session=%s" % session)
+            trainer = model.trainer
+            print ("train_ops = %s" % trainer.train_ops)
+            top = trainer.train_ops[0]
+            vmtset = top.validation_monitors_T
+            print ("validation_monitors_T = %s" % vmtset)
+            with model.session.as_default():
+                ats_var_val = tflearn.variables.get_value(vmtset[0])
+                ats_const_val = tflearn.variables.get_value(vmtset[1])
+            print ("summary values: var=%s, const=%s" % (ats_var_val, ats_const_val))
+            self.assertTrue(ats_const_val==32)	# test to make sure the constant made it through
+    
+            # TBD: parse the recorded tensorboard events and ensure the validation monitor variables show up there
+    
+class TestValidationBatch(unittest.TestCase):
+    """
+    Testing Validation Batch size specification
+    """
 
-        # construct two varaibles to add as additional "valiation monitors"
-        # these varaibles are evaluated each time validation happens (eg at a snapshot)
-        # and the results are summarized and output to the tensorboard events file,
-        # together with the accuracy and loss plots.
-        #
-        # Here, we generate a dummy variable given by the sum over the current
-        # network tensor, and a constant variable.  In practice, the validation
-        # monitor may present useful information, like confusion matrix
-        # entries, or an AUC metric.
-        with tf.name_scope('CustomMonitor'):
-            test_var = tf.reduce_sum(tf.cast(network, tf.float32), name="test_var")
-            test_const = tf.constant(32.0, name="custom_constant")
+    def test_vbs1(self):
 
-        print ("network=%s, test_var=%s" % (network, test_var))
-        network = fully_connected(network, 10, activation='softmax')
-        network = regression(network, optimizer='adam', learning_rate=0.01,
-                             loss='categorical_crossentropy', name='target', validation_monitors=[test_var, test_const])
-        
-        # Training
-        model = tflearn.DNN(network, tensorboard_verbose=3)
-        model.fit({'input': X}, {'target': Y}, n_epoch=1,
-                   validation_set=({'input': testX}, {'target': testY}),
-                   snapshot_step=10, show_metric=True, run_id='convnet_mnist')
-        
-        # check for validation monitor variables
-        ats = tf.get_collection("Adam_testing_summaries")
-        print ("ats=%s" % ats)
-        self.assertTrue(len(ats)==4)	# should be four variables being summarized: [loss, test_var, test_const, accuracy]
-        
-        session = model.session
-        print ("session=%s" % session)
-        trainer = model.trainer
-        print ("train_ops = %s" % trainer.train_ops)
-        top = trainer.train_ops[0]
-        vmtset = top.validation_monitors_T
-        print ("validation_monitors_T = %s" % vmtset)
-        with model.session.as_default():
-            ats_var_val = tflearn.variables.get_value(vmtset[0])
-            ats_const_val = tflearn.variables.get_value(vmtset[1])
-        print ("summary values: var=%s, const=%s" % (ats_var_val, ats_const_val))
-        self.assertTrue(ats_const_val==32)	# test to make sure the constant made it through
-
-        # TBD: parse the recorded tensorboard events and ensure the validation monitor variables show up there
-
+        with tf.Graph().as_default():
+            # Data loading and preprocessing
+            import tflearn.datasets.mnist as mnist
+            X, Y, testX, testY = mnist.load_data(one_hot=True)
+            X = X.reshape([-1, 28, 28, 1])
+            testX = testX.reshape([-1, 28, 28, 1])
+            X = X[:20, :, :, :]
+            Y = Y[:20, :]
+            testX = testX[:10, :, :, :]
+            testY = testY[:10, :]
+            
+            # Building convolutional network
+            network = input_data(shape=[None, 28, 28, 1], name='input')
+            network = conv_2d(network, 32, 3, activation='relu', regularizer="L2")
+            network = max_pool_2d(network, 2)
+            network = local_response_normalization(network)
+            network = conv_2d(network, 64, 3, activation='relu', regularizer="L2")
+            network = max_pool_2d(network, 2)
+            network = local_response_normalization(network)
+            network = fully_connected(network, 128, activation='tanh')
+            network = dropout(network, 0.8)
+            network = fully_connected(network, 256, activation='tanh')
+            network = dropout(network, 0.8)
+            network = fully_connected(network, 10, activation='softmax')
+            network = regression(network, optimizer='adam', learning_rate=0.01,
+                                 loss='categorical_crossentropy', name='target')
+            
+            # Training
+            model = tflearn.DNN(network, tensorboard_verbose=3)
+            model.fit({'input': X}, {'target': Y}, n_epoch=1,
+                      batch_size=10,
+                      validation_set=({'input': testX}, {'target': testY}),
+                      validation_batch_size=5,
+                      snapshot_step=10, show_metric=True, run_id='convnet_mnist_vbs')
+    
+            self.assertEqual(model.train_ops[0].validation_batch_size, 5)
+            self.assertEqual(model.train_ops[0].batch_size, 10)
+    
 if __name__ == "__main__":
     unittest.main()

--- a/tflearn/data_flow.py
+++ b/tflearn/data_flow.py
@@ -180,15 +180,7 @@ class FeedDictFlow(DataFlow):
             batch_ids = self.batch_ids_queue.get()
             if batch_ids is False:
                 break
-            # ichuang DEBUG
-            try:
-                data = self.retrieve_data(batch_ids)
-            except Exception as err:
-                print ("Failed in FeedDictFlow.fill_feed_dict_queue with err=%s" % (str(err)))
-                print ("    batch_size=%s, feed_dict_size=%s" % (self.batch_size, len(self.feed_dict)))
-                fdx = self.feed_dict.keys()[0]
-                print ("    feed dict %s shape %s" % (fdx, self.feed_dict[fdx].shape))
-                raise
+            data = self.retrieve_data(batch_ids)
             # Apply augmentation according to daug dict
             if self.daug_dict:
                 for k in self.daug_dict:

--- a/tflearn/data_flow.py
+++ b/tflearn/data_flow.py
@@ -180,7 +180,15 @@ class FeedDictFlow(DataFlow):
             batch_ids = self.batch_ids_queue.get()
             if batch_ids is False:
                 break
-            data = self.retrieve_data(batch_ids)
+            # ichuang DEBUG
+            try:
+                data = self.retrieve_data(batch_ids)
+            except Exception as err:
+                print ("Failed in FeedDictFlow.fill_feed_dict_queue with err=%s" % (str(err)))
+                print ("    batch_size=%s, feed_dict_size=%s" % (self.batch_size, len(self.feed_dict)))
+                fdx = self.feed_dict.keys()[0]
+                print ("    feed dict %s shape %s" % (fdx, self.feed_dict[fdx].shape))
+                raise
             # Apply augmentation according to daug dict
             if self.daug_dict:
                 for k in self.daug_dict:

--- a/tflearn/helpers/trainer.py
+++ b/tflearn/helpers/trainer.py
@@ -515,6 +515,9 @@ class TrainOp(object):
             used to periodically record a confusion matrix or AUC metric, 
             during training.  Each variable should have rank 1, i.e. 
             shape [None].
+        validation_batch_size: `int` or None. If `int`, specifies the batch
+            size to be used for the validation data feed; otherwise 
+            defaults to being th esame as `batch_size`.
         name: `str`. A name for this class (optional).
         graph: `tf.Graph`. Tensorflow Graph to use for training. Default:
             default tf graph.
@@ -523,7 +526,7 @@ class TrainOp(object):
 
     def __init__(self, loss, optimizer, metric=None, batch_size=64, ema=0.,
                  trainable_vars=None, shuffle=True, step_tensor=None,
-                 validation_monitors=None, name=None, graph=None):
+                 validation_monitors=None, validation_batch_size=None, name=None, graph=None):
         self.graph = tf.get_default_graph()
         if graph:
             self.graph = graph
@@ -550,6 +553,7 @@ class TrainOp(object):
         self.shuffle = shuffle
 
         self.batch_size = batch_size
+        self.validation_batch_size = validation_batch_size or batch_size
         self.n_batches = 0
 
         self.ema = ema
@@ -726,7 +730,7 @@ class TrainOp(object):
         # every time testing
         if val_feed_dict:
             self.test_dflow = data_flow.FeedDictFlow(val_feed_dict, coord,
-                                                     batch_size=self.batch_size,
+                                                     batch_size=self.validation_batch_size,
                                                      dprep_dict=dprep_dict,
                                                      daug_dict=None,
                                                      index_array=self.val_index_array,

--- a/tflearn/layers/estimator.py
+++ b/tflearn/layers/estimator.py
@@ -16,7 +16,7 @@ def regression(incoming, placeholder=None, optimizer='adam',
                learning_rate=0.001, dtype=tf.float32, batch_size=64,
                shuffle_batches=True, to_one_hot=False, n_classes=None,
                trainable_vars=None, restore=True, op_name=None, 
-               validation_monitors=None, name=None):
+               validation_monitors=None, validation_batch_size=None, name=None):
     """ Regression.
 
     The regression layer is used in TFLearn to apply a regression (linear or
@@ -81,6 +81,8 @@ def regression(incoming, placeholder=None, optimizer='adam',
             used to periodically record a confusion matrix or AUC metric, 
             during training.  Each variable should have rank 1, i.e. 
             shape [None].
+        validation_batch_size: `int` or None. Specifies the batch
+            size to be used for the validation data feed.
         name: A name for this layer's placeholder scope.
 
     Attributes:
@@ -190,6 +192,7 @@ def regression(incoming, placeholder=None, optimizer='adam',
                     shuffle=shuffle_batches,
                     step_tensor=step_tensor,
                     validation_monitors=validation_monitors,
+                    validation_batch_size=validation_batch_size,
                     name=op_name)
 
     tf.add_to_collection(tf.GraphKeys.TRAIN_OPS, tr_op)

--- a/tflearn/models/dnn.py
+++ b/tflearn/models/dnn.py
@@ -88,7 +88,7 @@ class DNN(object):
     def fit(self, X_inputs, Y_targets, n_epoch=10, validation_set=None,
             show_metric=False, batch_size=None, shuffle=None,
             snapshot_epoch=True, snapshot_step=None, excl_trainops=None,
-            run_id=None, callbacks=[]):
+            validation_batch_size=None, run_id=None, callbacks=[]):
         """ Fit.
 
         Train model, feeding X_inputs and Y_targets to the network.
@@ -124,7 +124,11 @@ class DNN(object):
                 `float` (<1) to performs a data split over training data.
             show_metric: `bool`. Display or not accuracy at every step.
             batch_size: `int` or None. If `int`, overrides all network
-                estimators 'batch_size' by this value.
+                estimators 'batch_size' by this value.  Also overrides
+                `valiation_batch_size` if `int`, and if `valudation_batch_size`
+                is None.
+            validation_batch_size: `int` or None. If `int`, overrides all network
+                estimators 'validation_batch_size' by this value.
             shuffle: `bool` or None. If `bool`, overrides all network
                 estimators 'shuffle' by this value.
             snapshot_epoch: `bool`. If True, it will snapshot model at the end
@@ -149,6 +153,13 @@ class DNN(object):
         if batch_size:
             for train_op in self.train_ops:
                 train_op.batch_size = batch_size
+
+        if batch_size is not None and validation_batch_size is None:
+            validation_batch_size = batch_size
+
+        if validation_batch_size:
+            for train_op in self.train_ops:
+                train_op.validation_batch_size = validation_batch_size
 
         valX, valY = None, None
         if validation_set:


### PR DESCRIPTION
This PR adds two small features, both needed for a variety of modeling tasks, such as wide+deep models.  The features are:

1. A `binary_accuracy` metric, which computes the average number of equal elements, between two binary-valued float tensors.  Contrast this with the existing accuracy metric, which does the same, but for one-hot encoded tensors.

2. A `validation_batch_size` parameter, used to specify a different batch size to be used for validation, versus for training.  Before, the same batch size was used for both.

Unit tests included.