### PR TITLE
Fix link to cnn_sentence_classification.py

### DIFF
--- a/docs/templates/examples.md
+++ b/docs/templates/examples.md
@@ -37,7 +37,7 @@
 - [City Name Generation](https://github.com/tflearn/tflearn/blob/master/examples/nlp/lstm_generator_cityname.py). Generates new US-cities name, using LSTM network.
 - [Shakespeare Scripts Generation](https://github.com/tflearn/tflearn/blob/master/examples/nlp/lstm_generator_shakespeare.py). Generates new Shakespeare scripts, using LSTM network.
 - [Seq2seq](https://github.com/tflearn/tflearn/blob/master/examples/nlp/seq2seq_example.py). Pedagogical example of seq2seq recurrent network. See [this repo](https://github.com/ichuang/tflearn_seq2seq) for full instructions.
-- [CNN Seq](https://github.com/tflearn/tflearn/blob/master/examples/nlp/cnn_sequence_classification.py). Apply a 1-D convolutional network to classify sequence of words from IMDB sentiment dataset.
+- [CNN Seq](https://github.com/tflearn/tflearn/blob/master/examples/nlp/cnn_sentence_classification.py). Apply a 1-D convolutional network to classify sequence of words from IMDB sentiment dataset.
 
 ## Reinforcement Learning
 - [Atari Pacman 1-step Q-Learning](https://github.com/tflearn/tflearn/blob/master/examples/reinforcement_learning/atari_1step_qlearning.py). Teach a machine to play Atari games (Pacman by default) using 1-step Q-learning.

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,7 +37,7 @@
 - [City Name Generation](https://github.com/tflearn/tflearn/blob/master/examples/nlp/lstm_generator_cityname.py). Generates new US-cities name, using LSTM network.
 - [Shakespeare Scripts Generation](https://github.com/tflearn/tflearn/blob/master/examples/nlp/lstm_generator_shakespeare.py). Generates new Shakespeare scripts, using LSTM network.
 - [Seq2seq](https://github.com/tflearn/tflearn/blob/master/examples/nlp/seq2seq_example.py). Pedagogical example of seq2seq reccurent network. See [this repo](https://github.com/ichuang/tflearn_seq2seq) for full instructions.
-- [CNN Seq](https://github.com/tflearn/tflearn/blob/master/examples/nlp/cnn_sequence_classification.py). Apply a 1-D convolutional network to classify sequence of words from IMDB sentiment dataset.
+- [CNN Seq](https://github.com/tflearn/tflearn/blob/master/examples/nlp/cnn_sentence_classification.py). Apply a 1-D convolutional network to classify sequence of words from IMDB sentiment dataset.
 
 ## Reinforcement Learning
 - [Atari Pacman 1-step Q-Learning](https://github.com/tflearn/tflearn/blob/master/examples/reinforcement_learning/atari_1step_qlearning.py). Teach a machine to play Atari games (Pacman by default) using 1-step Q-learning.


### PR DESCRIPTION
Both links in `docs/templates/examples.md` and `examples/README.md` for the nlp cnn example are misspelled.
It should be `https://github.com/tflearn/tflearn/blob/master/examples/nlp/cnn_sentence_classification.py`
instead  of `https://github.com/tflearn/tflearn/blob/master/examples/nlp/cnn_sequence_classification.py `