### PR TITLE
Add method get_layer_by_name(name)

### DIFF
--- a/examples/basics/linear_regression.py
+++ b/examples/basics/linear_regression.py
@@ -20,5 +20,6 @@ print("\nRegression result:")
 print("Y = " + str(m.get_weights(linear.W)) +
       "*X + " + str(m.get_weights(linear.b)))
 
-print("\nTest prediction for x = 3.2 and y = 4.5:")
-print(m.predict([3.2, 4.5]))
+print("\nTest prediction for x = 3.2, 3.3, 3.4:")
+print(m.predict([3.2, 3.3, 3.4]))
+# should output (close, not exact) y = [1.5315033197402954, 1.5585315227508545, 1.5855598449707031]

--- a/tflearn/layers/__init__.py
+++ b/tflearn/layers/__init__.py
@@ -4,7 +4,8 @@ from .conv import conv_2d, max_pool_2d, avg_pool_2d, conv_1d, \
     highway_conv_1d, highway_conv_2d, upsample_2d, conv_3d, max_pool_3d, \
     avg_pool_3d
 from .core import input_data, dropout, custom_layer, reshape, flatten, \
-    activation, fully_connected, single_unit, one_hot_encoding, time_distributed
+    activation, fully_connected, single_unit, \
+    one_hot_encoding, time_distributed, get_layer_by_name
 from .normalization import batch_normalization, local_response_normalization
 from .estimator import regression
 from .recurrent import lstm, gru, simple_rnn, bidirectional_rnn, \

--- a/tflearn/layers/core.py
+++ b/tflearn/layers/core.py
@@ -630,3 +630,18 @@ def time_distributed(incoming, fn, args=None, scope=None):
     else:
         x = [fn(x[i], *args) for i in range(timestep)]
     return tf.concat(1, x)
+
+
+def get_layer_by_name(name):
+    """ get_layer_by_name.
+
+    Retrieve a layer, given its name.
+
+    Arguments:
+        name: `str`. The layer name.
+
+    Returns:
+        A list of Variables.
+
+    """
+    return tf.get_collection(tf.GraphKeys.LAYER_TENSOR + '/' + name)


### PR DESCRIPTION
Currently there is no way to access a layer, unless when setting pointer to it when creating the graph, e.g.

```python
g = tflearn.input_data(shape=[None, 784], name='input')
g = tflearn.fully_connected(g, 128, name='dense1')
# setting reference here
dense2 = tflearn.fully_connected(g, 256, name='dense2')
g = tflearn.fully_connected(dense2, 10, activation='softmax', name='softmax')

# ... then when wanting to retrieve various properties of the layer
# it is confusing to access them via indices
dense2_vars = tflearn.variables.get_layer_variables_by_name('dense2')
print('Dense2 layer weights:')
print(m.get_weights(dense2_vars[0]))
print('Dense2 layer biases:')
print(m.get_weights(dense2_vars[1]))

# To get them by `W` or `b` or other properties like `_W` etc.
# we need to refer via the variable set above
print('Dense2 layer weights:')
print(m.get_weights(dense2.W))
print('Dense2 layer biases:')
print(m.get_weights(dense2.b))
```

Preferably, we shd be able to retrieve layer, and do this:

```python
g = tflearn.input_data(shape=[None, 784], name='input')
g = tflearn.fully_connected(g, 128, name='dense1')
g = tflearn.fully_connected(g, 256, name='dense2')
g = tflearn.fully_connected(g, 10, activation='softmax', name='softmax')

dense2 = tflearn.get_layer_by_name('dense2')
print('Dense2 layer weights:')
print(m.get_weights(dense2.W))
print('Dense2 layer biases:')
print(m.get_weights(dense2.b))
```

**P/S** I have not added unit tests for it, maybe this method should be put under `variables.py` along with all the get methods, but since it's a "layer" method, I put it under `layers/core.py`. Let me know if that's ok.

Also psst: it seems there's no automated test suite and CI yet.