### PR TITLE
Apply softmax after global average pooling in network-in-network example

### DIFF
--- a/examples/images/network_in_network.py
+++ b/examples/images/network_in_network.py
@@ -45,7 +45,7 @@ network = conv_2d(network, 10, 1, activation='relu')
 network = avg_pool_2d(network, 8)
 network = flatten(network)
 network = regression(network, optimizer='adam',
-                     loss='categorical_crossentropy',
+                     loss='softmax_categorical_crossentropy',
                      learning_rate=0.001)
 
 # Training


### PR DESCRIPTION
I referred to network_in_network example and
applied the architecture to MNIST.
It looked fine in first few steps,
but suddenly accuracy and loss dropped:

![ss](https://cloud.githubusercontent.com/assets/7347125/18935062/7e69e5ec-8618-11e6-8181-1d54b43dadb3.png)

I read "[Network In Network](http://arxiv.org/pdf/1312.4400v3.pdf)" paper,
and I think softmax layer is needed after global average pooling layer.

This change works fine not only for MNIST but also original example,
improves convergence and accuracy for cifar-10.
