### PR TITLE
Fix set value with non default session

### DIFF
--- a/tflearn/variables.py
+++ b/tflearn/variables.py
@@ -141,7 +141,7 @@ def set_value(var, value, session=None):
     op = tf.assign(var, value=value)
     if not session:
         session = tf.get_default_session()
-    return op.eval(session)
+    return op.eval(session=session)
 
 
 def get_inputs_placeholder_by_name(name):


### PR DESCRIPTION
Tensorflow eval for an op expects a feed_dict, session. The current set_value passes session as the first argument (incorrectly assigning it to feed_dict). This pull fixes that by using the session keyword arg.