### PR TITLE
Fix control_flow_ops

### DIFF
--- a/tflearn/layers/normalization.py
+++ b/tflearn/layers/normalization.py
@@ -88,7 +88,7 @@ def batch_normalization(incoming, beta=0.0, gamma=1.0, epsilon=1e-5,
 
         # Retrieve variable managing training mode
         is_training = tflearn.get_training_mode()
-        mean, var = tf.python.control_flow_ops.cond(
+        mean, var = tf.cond(
             is_training, update_mean_var, lambda: (moving_mean, moving_variance))
 
         try:


### PR DESCRIPTION
Tensorflow 0.11 removes the ability to access python.control_flow_ops
tf.cond is (and was) the correct function
REF: https://github.com/tensorflow/tensorflow/issues/4616
Fixes #367 