### PR TITLE
file mode fix

### DIFF
--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -510,7 +510,7 @@ def image_preloader(target_path, image_shape, mode='file', normalize=True,
             images, labels = [], []
             for l in f.readlines():
                 l = l.strip('\n').split()
-                if not files_extension or any(flag in l(0) for flag in files_extension):
+                if not files_extension or any(flag in l[0] for flag in files_extension):
                     if filter_channel:
                         if get_img_channel(l[0]) != 3:
                             continue


### PR DESCRIPTION
prevents error found when running 'tflearn/blob/master/examples/images/vgg_network_finetuning.py' in file mode:
  File "/usr/local/lib/python2.7/dist-packages/tflearn/data_utils.py", line 511, in <genexpr>
    if not files_extension or any(flag in l(0) for flag in files_extension):
TypeError: 'list' object is not callable