### PR TITLE
Make NLP example able to use cyrillic script in UTF8

### DIFF
--- a/examples/nlp/lstm_generator_cityname.py
+++ b/examples/nlp/lstm_generator_cityname.py
@@ -14,8 +14,9 @@ if not os.path.isfile(path):
 
 maxlen = 20
 
+string_utf8 = open(path, "r").read().decode('utf-8')
 X, Y, char_idx = \
-    textfile_to_semi_redundant_sequences(path, seq_maxlen=maxlen, redun_step=3)
+    string_to_semi_redundant_sequences(string_utf8, seq_maxlen=maxlen, redun_step=3)
 
 g = tflearn.input_data(shape=[None, maxlen, len(char_idx)])
 g = tflearn.lstm(g, 512, return_seq=True)
@@ -32,13 +33,13 @@ m = tflearn.SequenceGenerator(g, dictionary=char_idx,
                               checkpoint_path='model_us_cities')
 
 for i in range(40):
-    seed = random_sequence_from_textfile(path, maxlen)
+    seed = random_sequence_from_string(string_utf8, maxlen)
     m.fit(X, Y, validation_set=0.1, batch_size=128,
           n_epoch=1, run_id='us_cities')
     print("-- TESTING...")
     print("-- Test with temperature of 1.2 --")
-    print(m.generate(30, temperature=1.2, seq_seed=seed))
+    print(m.generate(30, temperature=1.2, seq_seed=seed).encode('utf-8'))
     print("-- Test with temperature of 1.0 --")
-    print(m.generate(30, temperature=1.0, seq_seed=seed))
+    print(m.generate(30, temperature=1.0, seq_seed=seed).encode('utf-8'))
     print("-- Test with temperature of 0.5 --")
-    print(m.generate(30, temperature=0.5, seq_seed=seed))
+    print(m.generate(30, temperature=0.5, seq_seed=seed).encode('utf-8'))


### PR DESCRIPTION
The issue is:
When you try to train LSTM cityname generator on dataset contains non-latin symbols, for
example, Russian city names, this example starts work unproperly. RNN
output sequence is not a Russian symbols, but some ugly stuff, looks
like codepage fault.

I've found, that problem is in TFlearn function
"string_to_semi_redundant_sequences", in expressions "chars =
set(string)" and "enumerate(chars)" - when you feed it with cyrillic
utf-8 string, function treats this string's symbols in ASCII, so we
receive such dictionary char_idx:
{ '\x80': 1, '\x81': 2 ..... } etc.

As I've understood, Russian symbols in UTF-8 take more than one byte, so
it doesn't fit in "one-symbol key" of char_idx dictionary, and
information about them is lost.

The solution is - before we process training dataset with
"string_to_semi_redundant_sequences" the program should treat this
string as sequence of utf-8 characters like "\u044b\u043e\u0426", so
this way we receive correct dictionary, that we can use to compare
Russian symbols with their digital code representation in dictionary.
This way the dictionary have such kind of view:
{ u'7': 56, u'8': 68, u'9': 67, u'\u0410': 6, u'\u0411': 5, u'\u0412':
8, u'\u0413': 7, ... }

This solution potentially gives a chance to use in TFLearn any other
national language characters, that used UTF-8, not only Russian, but
maybe Ukrainian, Serbian, Malaysian, Hindi or what else.