### PR TITLE
Featurewise zero center and featurewise stdnorm fix

### DIFF
--- a/tflearn/data_preprocessing.py
+++ b/tflearn/data_preprocessing.py
@@ -197,14 +197,10 @@ class DataPreprocessing(object):
         return batch
 
     def _featurewise_zero_center(self, batch):
-        for i in range(len(batch)):
-            batch[i] -= self.global_mean.value
-        return batch
+        return batch - self.global_mean.value
 
     def _featurewise_stdnorm(self, batch):
-        for i in range(len(batch)):
-            batch[i] /= (self.global_std.value + _EPSILON)
-        return batch
+        return batch / (self.global_std.value + _EPSILON)
 
     def _zca_whitening(self, batch):
         for i in range(len(batch)):


### PR DESCRIPTION
This PR fixes featurewise zero centring and normalization in order to work also with datasets that are not `float32`.

It also replaces redundant for loop by numpy broadcasting.