### PR TITLE
Step timer

### DIFF
--- a/tflearn/callbacks.py
+++ b/tflearn/callbacks.py
@@ -125,8 +125,6 @@ class TermLogger(Callback):
 
     def on_batch_end(self, training_state, snapshot=False):
 
-        self.print_termlogs(training_state)
-
         if snapshot:
             self.snapshot_termlogs(training_state)
 
@@ -165,7 +163,7 @@ class TermLogger(Callback):
         if self.has_curses:
             sys.stdout.write(curses.tigetstr('cvvis').decode())
 
-    def termlogs(self, step=0, global_loss=None, global_acc=None):
+    def termlogs(self, step=0, global_loss=None, global_acc=None, step_time=None):
 
         termlogs = "Training Step: " + str(step) + " "
         if global_loss:
@@ -173,6 +171,8 @@ class TermLogger(Callback):
                         "%.5f" % global_loss + "\033[0m\033[0m"
         if global_acc and not self.display_type == "single":
             termlogs += " - avg acc: %.4f" % float(global_acc)
+        if step_time:
+            termlogs += " | time: %.3fs" % step_time
         termlogs += "\n"
         for i, data in enumerate(self.data):
             print_loss = ""
@@ -211,7 +211,8 @@ class TermLogger(Callback):
         termlogs = self.termlogs(
             step=training_state.step,
             global_loss=training_state.global_loss,
-            global_acc=training_state.global_acc)
+            global_acc=training_state.global_acc,
+            step_time=training_state.step_time)
 
         if self.has_ipython and not self.has_curses:
             clear_output(wait=True)
@@ -227,7 +228,8 @@ class TermLogger(Callback):
         termlogs = self.termlogs(
             step=training_state.step,
             global_loss=training_state.global_loss,
-            global_acc=training_state.global_acc)
+            global_acc=training_state.global_acc,
+            step_time=training_state.step_time)
 
         termlogs += "--\n"
 

--- a/tflearn/callbacks.py
+++ b/tflearn/callbacks.py
@@ -127,6 +127,8 @@ class TermLogger(Callback):
 
         if snapshot:
             self.snapshot_termlogs(training_state)
+        else:
+            self.print_termlogs(training_state)
 
     def on_sub_batch_start(self, training_state):
         pass

--- a/tflearn/helpers/trainer.py
+++ b/tflearn/helpers/trainer.py
@@ -2,6 +2,7 @@
 from __future__ import division, print_function, absolute_import
 
 import re
+import time
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.training import optimizer as tf_optimizer
@@ -296,7 +297,8 @@ class Trainer(object):
                     # which data input), so one epoch loop in a multi-inputs
                     # model is equal to max(data_input) size.
                     for batch_step in range(max_batches_len):
-
+                        # start the timer for current batch_step
+                        batch_start = time.time()
                         self.training_state.increaseStep()
                         self.training_state.resetGlobal()
 
@@ -316,6 +318,9 @@ class Trainer(object):
 
                             # Optimizer batch end
                             caller.on_sub_batch_end(self.training_state, i)
+
+                        # Update training state step_time
+                        self.training_state.step_time = time.time() - batch_start
 
                         # All optimizers batch end
                         self.session.run(self.incr_global_step)
@@ -974,6 +979,7 @@ class TrainingState(object):
         self.epoch = 0
         self.step = 0
         self.current_iter = 0
+        self.step_time = 0.0
 
         self.acc_value = None
         self.loss_value = None


### PR DESCRIPTION
* add a simple step timer into `TermLogger`
`$ python tflearn/examples/images/convnet_mnist.py` (for `snapshot_step=10`)
```
Training Step: 8  | total loss: 2.03040 | time: 0.275s
| Adam | epoch: 001 | loss: 2.03040 - acc: 0.2720 -- iter: 00512/55000
Training Step: 9  | total loss: 1.94953 | time: 0.186s
| Adam | epoch: 001 | loss: 1.94953 - acc: 0.2935 -- iter: 00576/55000
Training Step: 10  | total loss: 1.87821 | time: 8.900s
| Adam | epoch: 001 | loss: 1.87821 - acc: 0.3264 | val_loss: 1.42485 - val_acc: 0.5097 -- iter: 00640/55000
--
Training Step: 11  | total loss: 1.80984 | time: 0.326s
| Adam | epoch: 001 | loss: 1.80984 - acc: 0.3790 -- iter: 00704/55000
Training Step: 12  | total loss: 1.69605 | time: 0.291s
| Adam | epoch: 001 | loss: 1.69605 - acc: 0.4053 -- iter: 00768/55000
Training Step: 13  | total loss: 1.54950 | time: 0.245s
```

* remove redundant log for snapshot step
```
Training Step: 10  | total loss: 1.76443 | time: 8.365s
| Adam | epoch: 001 | loss: 1.76443 - acc: 0.4145 | val_loss: 1.28800 - val_acc: 0.5430 -- iter: 00640/55000
Training Step: 10  | total loss: 1.76443 | time: 8.365s
| Adam | epoch: 001 | loss: 1.76443 - acc: 0.4145 | val_loss: 1.28800 - val_acc: 0.5430 -- iter: 00640/55000
--
Training Step: 11  | total loss: 1.63371 | time: 0.188s
| Adam | epoch: 001 | loss: 1.63371 - acc: 0.4550 -- iter: 00704/55000
```
