### PR TITLE
Fix reference

### DIFF
--- a/docs/templates/getting_started.md
+++ b/docs/templates/getting_started.md
@@ -375,7 +375,7 @@ tflearn.is_training(False)
 ### Training Callbacks
 
 During the training cycle, TFLearn gives you the possibility to track and interact with the metrics of the training throughout a set of functions given by the [Callback](https://github.com/tflearn/tflearn/blob/master/tflearn/callbacks.py#L10) interface.
-To simplify the metrics retreivement, each callback method received a [TrainingState](https://github.com/tflearn/tflearn/blob/master/tflearn/helpers/trainer.py#L950) which track the state (e.g. : current epoch, step, batch iteration) and metrics (e.g. : current validation accuracy, global accuracy etc..)
+To simplify the metrics retreivement, each callback method received a [TrainingState](https://github.com/tflearn/tflearn/blob/master/tflearn/helpers/trainer.py#L976) which track the state (e.g. : current epoch, step, batch iteration) and metrics (e.g. : current validation accuracy, global accuracy etc..)
 
 Callback methods which relate to the training cycle : 
 - `on_train_begin(training_state)`


### PR DESCRIPTION
Fix reference of `class TrainingState`
Probably caused by not updating this file after the change of [tflearn/tflearn/helpers/trainer.py](https://github.com/tflearn/tflearn/blob/master/tflearn/helpers/trainer.py#L976)