### PR TITLE
PReLU Alphas do not respect variable_scope with reuse_variables

### DIFF
--- a/tflearn/activations.py
+++ b/tflearn/activations.py
@@ -226,10 +226,10 @@ def prelu(x, channel_shared=False, weights_init='zeros', restore=True, name="PRe
     i_scope = ""
     if hasattr(x, 'scope'):
         if x.scope: i_scope = x.scope
-    with tf.name_scope(i_scope + name) as scope:
+    with tf.variable_scope(i_scope + name) as scope:
         W_init = initializations.get(weights_init)()
         alphas = va.variable(shape=w_shape, initializer=W_init,
-                             restore=restore, name=scope + "alphas")
+                             restore=restore, name="alphas")
 
         x = tf.nn.relu(x) + tf.mul(alphas, (x - tf.abs(x))) * 0.5
 


### PR DESCRIPTION
Simple example failing on my system (tensorflow: 0.11, tflearn: latest):

```python
import tensorflow as tf
import tflearn
with tf.variable_scope('test') as scope:
    input_tensor = tf.placeholder(tf.float32, [None, 10])

    # initial create works fine
    l_hid1 = tflearn.fully_connected(input_tensor, 256, activation='prelu', scope='dense1')

    scope.reuse_variables()

    # second create fails at creating prelu alphas
    l_hid1 = tflearn.fully_connected(input_tensor, 256, activation='prelu', scope='dense1')
```

ValueError: Variable test/dense1/test/dense1_1/PReLU/alphas does not exist, or was not created with tf.get_variable(). Did you mean to set reuse=None in VarScope?

My use case is running the same graph with reuse variables to process a different input tensor. But I cannot do this with PReLU.

This stems from https://github.com/tflearn/tflearn/blob/master/tflearn/activations.py#L178.
Interestingly, tensorflow's name_scope does not respect reuse_variables so it creates a new name_scope for the second creation of alphas. 

If I replace the name_scope with variable_scope, everything works correctly. (Also variable_scope cannot be added to a string, so we just use the name "alphas" this will still correctly show in the graph).