### PR TITLE
Sensitive defaults to build_hdf5_image_dataset wrt to h5 chunking

### DIFF
--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -291,7 +291,7 @@ class VocabularyProcessor(_VocabularyProcessor):
 def build_hdf5_image_dataset(target_path, image_shape, output_path='dataset.h5',
                              mode='file', categorical_labels=True,
                              normalize=True, grayscale=False,
-                             files_extension=None, chunks=True):
+                             files_extension=None, chunks=False):
     """ Build HDF5 Image Dataset.
 
     Build an HDF5 dataset by providing either a root folder or a plain text
@@ -359,8 +359,9 @@ def build_hdf5_image_dataset(target_path, image_shape, output_path='dataset.h5',
         files_extension: `list of str`. A list of allowed image file
             extension, for example ['.jpg', '.jpeg', '.png']. If None,
             all files are allowed.
-        chunks: `bool` or `list of int`. Whether to chunks the dataset or not.
-            Additionaly, a specific shape for each chunk can be provided.
+        chunks: `bool` Whether to chunks the dataset or not. You should use
+            chunking when you really need it. See HDF5 documentation.
+            If chunks is 'True' a sensitive default will be computed.
 
     """
     import h5py
@@ -387,10 +388,15 @@ def build_hdf5_image_dataset(target_path, image_shape, output_path='dataset.h5',
         if not grayscale else (len(images), image_shape[0], image_shape[1])
     d_labelshape = (len(images), n_classes) \
         if categorical_labels else (len(images), )
-
+    x_chunks = None
+    y_chunks = None
+    if chunks is True:
+        x_chunks = (1,)+ d_imgshape[1:]
+        if len(d_labelshape) > 1:
+            y_chunks = (1,) + d_labelshape[1:]
     dataset = h5py.File(output_path, 'w')
-    dataset.create_dataset('X', d_imgshape, chunks=chunks)
-    dataset.create_dataset('Y', d_labelshape, chunks=chunks)
+    dataset.create_dataset('X', d_imgshape, chunks=x_chunks)
+    dataset.create_dataset('Y', d_labelshape, chunks=y_chunks)
 
     for i in range(len(images)):
         img = load_image(images[i])

--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -360,7 +360,7 @@ def build_hdf5_image_dataset(target_path, image_shape, output_path='dataset.h5',
             extension, for example ['.jpg', '.jpeg', '.png']. If None,
             all files are allowed.
         chunks: `bool` Whether to chunks the dataset or not. You should use
-            chunking when you really need it. See HDF5 documentation.
+            chunking only when you really need it. See HDF5 documentation.
             If chunks is 'True' a sensitive default will be computed.
 
     """


### PR DESCRIPTION
After some extensive testing (see issue #495) I removed default chunking. If one really needs h5 chunks, better-than-default chunk size is computed.