### PR TITLE
trainer: redefine assign ops for Tensorboard validation loss/acc/monitors

### DIFF
--- a/tflearn/helpers/trainer.py
+++ b/tflearn/helpers/trainer.py
@@ -815,9 +815,11 @@ class TrainOp(object):
                 eval_ops.append(self.metric)
             e = evaluate_flow(self.session, eval_ops, self.test_dflow)
             self.val_loss = e[0]
-            self.validation_monitor_values = e[1:-1]
             if show_metric and self.metric is not None:
+                self.validation_monitor_values = e[1:-1]
                 self.val_acc = e[-1]
+            else:
+                self.validation_monitor_values = e[1:]
 
             # Set evaluation results to variables, to be summarized.
             update_val_op = [self.val_loss_assign]

--- a/tflearn/helpers/trainer.py
+++ b/tflearn/helpers/trainer.py
@@ -620,11 +620,24 @@ class TrainOp(object):
         """
         self.session = session
 
-        # Variables holding mean validation loss and accuracy, assigned after
-        # each model evaluation (by batch). For visualization in Tensorboard.
+        # Variables holding mean validation loss, accuracy, and validation
+        # monitors, assigned after each model evaluation (by batch).
+        # For visualization in Tensorboard.
+        # Define variables, placeholders and assign ops.
         self.val_loss_T = tf.Variable(0., name='val_loss', trainable=False)
         self.val_acc_T = tf.Variable(0., name='val_acc', trainable=False)
         self.validation_monitors_T = [tf.Variable(0., name='%s_T' % v.name.rsplit(':', 1)[0], trainable=False) for v in self.validation_monitors]
+
+        self.val_loss_P = tf.placeholder(dtype=tf.float32, name='placeholder/%s' % self.val_loss_T.name.rsplit(':')[0])
+        self.val_acc_P = tf.placeholder(dtype=tf.float32, name='placeholder/%s' % self.val_acc_T.name.rsplit(':')[0])
+        self.val_monitors_P = [tf.placeholder(dtype=tf.float32, name='placeholder/%s' % v.name.rsplit(':')[0]) for v in self.validation_monitors_T]
+
+        self.val_loss_assign = tf.assign(self.val_loss_T, self.val_loss_P,
+                                         name='assign/%s' % self.val_loss_T.name.rsplit(':')[0])
+        self.val_acc_assign = tf.assign(self.val_acc_T, self.val_acc_P,
+                                        name='assign/%s' % self.val_acc_T.name.rsplit(':')[0])
+        self.val_monitors_assign = [tf.assign(vmt, vmp, name='assign/%s' % vmt.name.rsplit(':')[0]) for vmt, vmp in
+                                    zip(self.validation_monitors_T, self.val_monitors_P)]
 
         # Creating the accuracy moving average, for better visualization.
         if self.metric is not None:
@@ -807,13 +820,17 @@ class TrainOp(object):
                 self.val_acc = e[-1]
 
             # Set evaluation results to variables, to be summarized.
-            update_val_op = [tf.assign(self.val_loss_T, self.val_loss)]
+            update_val_op = [self.val_loss_assign]
+            update_val_feed = {self.val_loss_P: self.val_loss}
             if show_metric:
-                update_val_op.append(tf.assign(self.val_acc_T, self.val_acc))
+                update_val_op.append(self.val_acc_assign)
+                update_val_feed[self.val_acc_P] = self.val_acc
             if self.validation_monitors:
-                for vmt, vm in zip(self.validation_monitors_T, self.validation_monitor_values):
-                    update_val_op.append(tf.assign(vmt, vm))
-            self.session.run(update_val_op)
+                update_val_op.append(self.val_monitors_assign)
+                for vmp, vmv in zip(self.val_monitors_P, self.validation_monitor_values):
+                    update_val_feed[vmp] = vmv
+
+            self.session.run(update_val_op, feed_dict=update_val_feed)
 
             # Run summary operation.
             test_summ_str = self.session.run(self.val_summary_op)


### PR DESCRIPTION
Replace creation of assign ops in the validation step with placeholders and fixed assign ops. This prevents adding new nodes into graph each time the validation is calculated.

Compare **Num operations:** log for `examples/images/convnet_mnist.py` with `snapshot_step=3`
For this comparison, **Num operations:** was logged using `print('Num operations: ', len(self.graph.get_operations()))` for each batch.

### Original implementation
```
Extracting mnist/train-images-idx3-ubyte.gz
Extracting mnist/train-labels-idx1-ubyte.gz
Extracting mnist/t10k-images-idx3-ubyte.gz
Extracting mnist/t10k-labels-idx1-ubyte.gz
---------------------------------
Run id: convnet_mnist
Log directory: /tmp/mnist_run/tensorboard_logs/
---------------------------------
Training samples: 55000
Validation samples: 10000
--
Num operations:  1273
Training Step: 1  | time: 0.280s
| Adam | epoch: 001 | loss: 0.00000 - acc: 0.0000 -- iter: 00064/55000
Num operations:  1273
Training Step: 2  | total loss: 2.07048 | time: 0.154s
| Adam | epoch: 001 | loss: 2.07048 - acc: 0.0844 -- iter: 00128/55000
Num operations:  1273
Training Step: 3  | total loss: 2.24637 | time: 6.836s
| Adam | epoch: 001 | loss: 2.24637 - acc: 0.1432 | val_loss: 2.37714 - val_acc: 0.0893 -- iter: 00192/55000
--
Num operations:  1281
Training Step: 4  | total loss: 2.55987 | time: 0.126s
| Adam | epoch: 001 | loss: 2.55987 - acc: 0.0710 -- iter: 00256/55000
Num operations:  1281
Training Step: 5  | total loss: 2.41186 | time: 0.140s
| Adam | epoch: 001 | loss: 2.41186 - acc: 0.1300 -- iter: 00320/55000
Num operations:  1281
Training Step: 6  | total loss: 2.27070 | time: 6.357s
| Adam | epoch: 001 | loss: 2.27070 - acc: 0.2373 | val_loss: 2.06145 - val_acc: 0.3165 -- iter: 00384/55000
--
Num operations:  1289
Training Step: 7  | total loss: 2.20102 | time: 0.126s
| Adam | epoch: 001 | loss: 2.20102 - acc: 0.1699 -- iter: 00448/55000
Num operations:  1289
Training Step: 8  | total loss: 2.15400 | time: 0.183s
| Adam | epoch: 001 | loss: 2.15400 - acc: 0.2413 -- iter: 00512/55000
Num operations:  1289
```
### Fixed implementation
```

Extracting mnist/train-images-idx3-ubyte.gz
Extracting mnist/train-labels-idx1-ubyte.gz
Extracting mnist/t10k-images-idx3-ubyte.gz
Extracting mnist/t10k-labels-idx1-ubyte.gz
---------------------------------
Run id: convnet_mnist
Log directory: /tmp/mnist_run/tensorboard_logs/
---------------------------------
Training samples: 55000
Validation samples: 10000
--
Num operations:  1273
Training Step: 1  | time: 0.352s
| Adam | epoch: 001 | loss: 0.00000 - acc: 0.0000 -- iter: 00064/55000
Num operations:  1273
Training Step: 2  | total loss: 2.07085 | time: 0.187s
| Adam | epoch: 001 | loss: 2.07085 - acc: 0.1547 -- iter: 00128/55000
Num operations:  1273
Training Step: 3  | total loss: 2.22889 | time: 6.454s
| Adam | epoch: 001 | loss: 2.22889 - acc: 0.2455 | val_loss: 2.05941 - val_acc: 0.3142 -- iter: 00192/55000
--
Num operations:  1273
Training Step: 4  | total loss: 2.33421 | time: 0.119s
| Adam | epoch: 001 | loss: 2.33421 - acc: 0.1434 -- iter: 00256/55000
Num operations:  1273
Training Step: 5  | total loss: 2.28808 | time: 0.148s
| Adam | epoch: 001 | loss: 2.28808 - acc: 0.2064 -- iter: 00320/55000
Num operations:  1273
Training Step: 6  | total loss: 2.09713 | time: 7.295s
| Adam | epoch: 001 | loss: 2.09713 - acc: 0.2746 | val_loss: 1.61467 - val_acc: 0.4207 -- iter: 00384/55000
--
Num operations:  1273
Training Step: 7  | total loss: 1.94789 | time: 0.123s
| Adam | epoch: 001 | loss: 1.94789 - acc: 0.3442 -- iter: 00448/55000
Num operations:  1273
Training Step: 8  | total loss: 1.81383 | time: 0.139s
| Adam | epoch: 001 | loss: 1.81383 - acc: 0.3879 -- iter: 00512/55000
Num operations:  1273
```