### PR TITLE
Fix "Using a `tf.Tensor` as a Python `bool` is not allowed"

### DIFF
--- a/tflearn/layers/conv.py
+++ b/tflearn/layers/conv.py
@@ -65,7 +65,7 @@ def conv_2d(incoming, nb_filter, filter_size, strides=1, padding='same',
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
         W_regul = None
-        if regularizer:
+        if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
         W = vs.variable(scope + 'W', shape=filter_size,
                         regularizer=W_regul, initializer=W_init,
@@ -74,7 +74,7 @@ def conv_2d(incoming, nb_filter, filter_size, strides=1, padding='same',
         tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + scope, W)
 
         b = None
-        if bias:
+        if bias is not None:
             b_init = initializations.get(bias_init)()
             b = vs.variable(scope + 'b', shape=nb_filter,
                             initializer=b_init, trainable=trainable,
@@ -83,7 +83,7 @@ def conv_2d(incoming, nb_filter, filter_size, strides=1, padding='same',
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + scope, b)
 
         inference = tf.nn.conv2d(incoming, W, strides, padding)
-        if b: inference = tf.nn.bias_add(inference, b)
+        if b is not None: inference = tf.nn.bias_add(inference, b)
         inference = activations.get(activation)(inference)
 
         # Track activations.
@@ -155,7 +155,7 @@ def conv_2d_transpose(incoming, nb_filter, filter_size, strides=1,
 
         W_init = initializations.get(weights_init)()
         W_regul = None
-        if regularizer:
+        if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
         W = vs.variable(scope + 'W', shape=filter_size,
                         regularizer=W_regul, initializer=W_init,
@@ -164,7 +164,7 @@ def conv_2d_transpose(incoming, nb_filter, filter_size, strides=1,
         tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + scope, W)
 
         b = None
-        if bias:
+        if bias is not None:
             b_init = initializations.get(bias_init)()
             b = vs.variable(scope + 'b', shape=nb_filter,
                             initializer=b_init, trainable=trainable,
@@ -173,7 +173,7 @@ def conv_2d_transpose(incoming, nb_filter, filter_size, strides=1,
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + scope, b)
 
         inference = tf.nn.conv2d_transpose(incoming, W, strides, padding)
-        if b: inference = tf.nn.bias_add(inference, b)
+        if b is not None: inference = tf.nn.bias_add(inference, b)
         inference = activations.get(activation)(inference)
 
         # Track activations.
@@ -323,7 +323,7 @@ def conv_1d(incoming, nb_filter, filter_size, strides=1, padding='same',
 
         W_init = initializations.get(weights_init)()
         W_regul = None
-        if regularizer:
+        if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
         W = vs.variable(scope + 'W', shape=filter_size,
                         regularizer=W_regul, initializer=W_init,
@@ -332,7 +332,7 @@ def conv_1d(incoming, nb_filter, filter_size, strides=1, padding='same',
         tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + scope, W)
 
         b = None
-        if bias:
+        if bias is not None:
             b_init = initializations.get(bias_init)()
             b = vs.variable(scope + 'b', shape=nb_filter,
                             initializer=b_init, trainable=trainable,
@@ -343,7 +343,7 @@ def conv_1d(incoming, nb_filter, filter_size, strides=1, padding='same',
         # Adding dummy dimension to fit with Tensorflow conv2d
         inference = tf.expand_dims(incoming, 2)
         inference = tf.nn.conv2d(inference, W, strides, padding)
-        if b: inference = tf.nn.bias_add(inference, b)
+        if b is not None: inference = tf.nn.bias_add(inference, b)
         inference = tf.squeeze(inference, [2])
         inference = activations.get(activation)(inference)
 

--- a/tflearn/layers/core.py
+++ b/tflearn/layers/core.py
@@ -47,7 +47,7 @@ def input_data(shape=None, placeholder=None, dtype=tf.float32,
     if not shape and not placeholder:
         raise Exception("`shape` or `placeholder` argument is required.")
 
-    if not placeholder:
+    if placeholder is None:
         # Add 'None' if missing
         assert shape is not None, "A shape or a placeholder must be provided."
         if len(shape) > 1:
@@ -111,7 +111,7 @@ def fully_connected(incoming, n_units, activation='linear', bias=True,
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
         W_regul = None
-        if regularizer:
+        if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
         W = va.variable(scope + 'W', shape=[n_inputs, n_units],
                         regularizer=W_regul, initializer=W_init,
@@ -119,7 +119,7 @@ def fully_connected(incoming, n_units, activation='linear', bias=True,
         tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + scope, W)
 
         b = None
-        if bias:
+        if bias is not None:
             b_init = initializations.get(bias_init)()
             b = va.variable(scope + 'b', shape=[n_units],
                             initializer=b_init, trainable=trainable,
@@ -132,7 +132,7 @@ def fully_connected(incoming, n_units, activation='linear', bias=True,
             inference = tf.reshape(inference, [-1, n_inputs])
 
         inference = tf.matmul(inference, W)
-        if b: inference = tf.nn.bias_add(inference, b)
+        if b is not None: inference = tf.nn.bias_add(inference, b)
         inference = activations.get(activation)(inference)
 
         # Track activations.
@@ -313,7 +313,7 @@ def single_unit(incoming, activation='linear', bias=True, trainable=True,
         tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + scope, W)
 
         b = None
-        if bias:
+        if bias is not None:
             b = va.variable(scope + 'b', shape=[n_inputs],
                             initializer=tf.constant_initializer(np.random.randn()),
                             trainable=trainable, restore=restore)
@@ -325,7 +325,7 @@ def single_unit(incoming, activation='linear', bias=True, trainable=True,
             inference = tf.reshape(inference, [-1])
 
         inference = tf.mul(inference, W)
-        if b: inference = tf.add(inference, b)
+        if b is not None: inference = tf.add(inference, b)
         inference = activations.get(activation)(inference)
 
         # Track activations.

--- a/tflearn/layers/estimator.py
+++ b/tflearn/layers/estimator.py
@@ -53,7 +53,7 @@ def regression(incoming, placeholder=None, optimizer='adam',
 
     input_shape = utils.get_incoming_shape(incoming)
 
-    if not placeholder:
+    if placeholder is None:
         pscope = "TargetsData" if not name else name
         with tf.name_scope(pscope):
             pshape = [None, input_shape[-1]]


### PR DESCRIPTION
At the current version of tflearn, using some modules could end up with:

> TypeError: Using a `tf.Tensor` as a Python `bool` is not allowed. Use `if t is not None:` instead of `if t:` to test if a tensor is defined, and use TensorFlow ops such as tf.cond to execute subgraphs conditioned on the value of a tensor.

So I replaced some judgements like "if b:" to "if b is not None" to avoid this.