### PR TITLE
Removed Curses Dependency for Windows Support

### DIFF
--- a/tflearn/utils.py
+++ b/tflearn/utils.py
@@ -8,7 +8,7 @@ try:
     import h5py
     H5PY_SUPPORTED = True
 except Exception as e:
-    print("hdf5 not supported (please install/reinstall h5py)")
+    print("hdf5 is not supported on this machine (please install/reinstall h5py for optimal experience)")
     H5PY_SUPPORTED = False
 import numpy as np
 import tensorflow as tf


### PR DESCRIPTION
As we move towards building for windows, it is probably a good idea to remove a direct reliance on the Curses library. May still have a bug in the on_train_end function when working in iPython, which was not resolved by this commit. I also edited the h5py error message to preserve consistency across dependency messages. 