### PR TITLE
Fix a problem that Failing to get value from summary string

### DIFF
--- a/tflearn/summaries.py
+++ b/tflearn/summaries.py
@@ -197,7 +197,7 @@ def get_value_from_summary_string(tag, summary_str):
     summ.ParseFromString(summary_str)
 
     for row in summ.value:
-        if row.tag == tag:
+        if row.tag.endswith(tag):
             return float(row.simple_value)
 
     raise ValueError("Tag: " + tag + " cannot be found in summaries list.")


### PR DESCRIPTION
This problem caused the sample logical.py code failed with exception error message like below 

--
Traceback (most recent call last):
  File "t_logical.py", line 113, in <module>
    m.fit(X, [Y_nand, Y_or], n_epoch=400, snapshot_epoch=False)
  File "/home/xgu/git/tflearn_noguxun/tflearn/models/dnn.py", line 215, in fit
    callbacks=callbacks)
  File "/home/xgu/git/tflearn_noguxun/tflearn/helpers/trainer.py", line 333, in fit
    show_metric)
  File "/home/xgu/git/tflearn_noguxun/tflearn/helpers/trainer.py", line 779, in _train
    sname, train_summ_str)
  File "/home/xgu/git/tflearn_noguxun/tflearn/summaries.py", line 205, in get_value_from_summary_string
    raise ValueError("Tag: " + tag + " cannot be found in summaries list.")
ValueError: Tag: Loss/SGD_0 cannot be found in summaries list.


Cause: 

In function 
def get_value_from_summary_string(tag, summary_str):

    for row in summ.value:
        print(tag)
        print(row.tag)
        
We get below print result
Loss/SGD_0
SGD_0/Loss/SGD_0


