### PR TITLE
downsample with true averaging for residual network

### DIFF
--- a/tflearn/layers/conv.py
+++ b/tflearn/layers/conv.py
@@ -1203,7 +1203,7 @@ def residual_block(incoming, nb_blocks, out_channels, downsample=False,
 
             # Downsampling
             if downsample_strides > 1:
-                identity = tflearn.avg_pool_2d(identity, 1,
+                identity = tflearn.avg_pool_2d(identity, downsample_strides,
                                                downsample_strides)
 
             # Projection to new dimension
@@ -1327,7 +1327,7 @@ def residual_bottleneck(incoming, nb_blocks, bottleneck_size, out_channels,
 
             # Downsampling
             if downsample_strides > 1:
-                identity = tflearn.avg_pool_2d(identity, 1,
+                identity = tflearn.avg_pool_2d(identity, downsample_strides,
                                                downsample_strides)
 
             # Projection to new dimension


### PR DESCRIPTION
I used Example: residual_network_mnist.py, and got an **exception**: "InvalidArgumentError (see above for traceback): stride must be less than or equal to kernel size" (with tensorflow-0.12.1). I see the function "avg_pool_2d" is used to do downsample work, but kernel_size is set to 1, which induce fake averaging.  So, I think let kernel_size=downsample_strides will do real averaging downsample and meanwhile fix the exception above. I did so, and it works.