### PR TITLE
Fix #548 - HDF5 non-square Broadcast Error

### DIFF
--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -384,7 +384,7 @@ def build_hdf5_image_dataset(target_path, image_shape, output_path='dataset.h5',
 
     n_classes = np.max(labels) + 1
 
-    d_imgshape = (len(images), image_shape[0], image_shape[1], 3) \
+    d_imgshape = (len(images), image_shape[1], image_shape[0], 3) \
         if not grayscale else (len(images), image_shape[0], image_shape[1])
     d_labelshape = (len(images), n_classes) \
         if categorical_labels else (len(images), )


### PR DESCRIPTION
When generating HDF5 data shape mismatch issues within TFLearn were causing errors to be thrown lower down in h5py. Namely, "Type Error: Can't broadcast error".

Related issues: https://github.com/h5py/h5py/issues/844 and https://github.com/tflearn/tflearn/issues/548 from what I could briefly find prior to solving this for myself.

After lengthy debug processes, I found that the target shape and count shape appeared to be inverted to each other for width and height; eventually tracing the cause of the problem back to the initialisation of 'Dataset' grabbing the wrong width and height.

Even swapping the passed in dimensions to `build_hdf5_image_dataset` they were always inverted.

I am inexperienced with hdf5 files, and/or their use in tflearn; however OpenCV uses [ Height, Width ] notation.

With this proposed change, no errors are thrown in h5py relating to boundary.