### PR TITLE
Fix/residual block 

### DIFF
--- a/tflearn/layers/conv.py
+++ b/tflearn/layers/conv.py
@@ -1164,8 +1164,7 @@ def residual_block(incoming, nb_blocks, out_channels, downsample=False,
 
             # Downsampling
             if downsample_strides > 1:
-                identity = tflearn.avg_pool_2d(identity, downsample_strides,
-                                               downsample_strides)
+                identity = tflearn.avg_pool_2d(identity, 1, downsample_strides)
 
             # Projection to new dimension
             if in_channels != out_channels:


### PR DESCRIPTION
This PR fixes the residual block, where was previously being passed `downsample_strides` as `avg_pool_2d`'s kernel size.
It also solves different results obtained from nets (than in older versions of tflearn) as reported in https://github.com/tflearn/tflearn/issues/624