### PR TITLE
Fixed HDF5 Greyscale non-square broadcast error

### DIFF
--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -384,7 +384,7 @@ def build_hdf5_image_dataset(target_path, image_shape, output_path='dataset.h5',
     n_classes = np.max(labels) + 1
 
     d_imgshape = (len(images), image_shape[1], image_shape[0], 3) \
-        if not grayscale else (len(images), image_shape[0], image_shape[1])
+        if not grayscale else (len(images), image_shape[1], image_shape[0])
     d_labelshape = (len(images), n_classes) \
         if categorical_labels else (len(images), )
     x_chunks = None


### PR DESCRIPTION
Related to #548 & #614 but for greyscale images. Caused a broadcast error as the check would always fail, as the check would have width and height flipped; thus fails for any non-square image.

This relates to my previous PR. Admittedly I should have additionally fixed greyscale images which suffer from the same 'swapped' fate. When constructing a greyscale dataset I came across the familiar broadcast error message.

After applying the proposed fix a greyscale non-square image set can be built. @aymericdamien, pinging you as you approved the previous PR, feel free to confirm.
```python
build_hdf5_image_dataset(str(info_file), image_shape=[851, 457],
                             mode='file', output_path=str(hdf5_file), grayscale=True,
                             categorical_labels=True, normalize=True)
```
for info.