### PR TITLE
fixed generator append unicode char

### DIFF
--- a/tflearn/models/generator.py
+++ b/tflearn/models/generator.py
@@ -217,7 +217,7 @@ class SequenceGenerator(object):
             next_index = _sample(preds, temperature)
             next_char = self.rev_dic[next_index]
 
-            if type(sequence) == str:
+            if type(sequence) == str or type(sequence) == unicode:
                 generated += next_char
                 sequence = sequence[1:] + next_char
                 whole_sequence += next_char


### PR DESCRIPTION
fixed: got error message "'unicode' object has no attribute 'append'" when running example lstm_generator_cityname.py