### PR TITLE
Update trainer.py in tflearn\examples\extending_tensorflow\

### DIFF
--- a/examples/extending_tensorflow/trainer.py
+++ b/examples/extending_tensorflow/trainer.py
@@ -36,7 +36,7 @@ with tf.Graph().as_default():
         return x
 
     net = dnn(X)
-    loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(net, Y))
+    loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(logits=net, labels=Y))
     optimizer = tf.train.GradientDescentOptimizer(learning_rate=0.1)
     accuracy = tf.reduce_mean(
         tf.cast(tf.equal(tf.argmax(net, 1), tf.argmax(Y, 1)), tf.float32),


### PR DESCRIPTION
In relation to issue https://github.com/tflearn/tflearn/issues/639

Updating code to TensorFlow 1.0 as now requiring the names of arguments when using tf.nn.softmax_cross_entropy_with_logits.

Source: https://github.com/ibab/tensorflow-wavenet/issues/223#issuecomment-284415570