### PR TITLE
Fixed a bug on DNN.predict_label

### DIFF
--- a/tflearn/models/dnn.py
+++ b/tflearn/models/dnn.py
@@ -245,7 +245,11 @@ class DNN(object):
 
         """
         feed_dict = feed_dict_builder(X, None, self.inputs, None)
-        return np.argsort(self.predictor.predict(feed_dict))[::-1]
+        labels = np.argsort(self.predictor.predict(feed_dict))
+        if labels.ndim == 1:
+            return labels[::-1]
+        else:
+            return labels[:, ::-1]
 
     def save(self, model_file):
         """ Save.


### PR DESCRIPTION
Following to the docs, `DNN#predict_label` should return an array of predicted classes index. (sorted by descendant probability value.)

```python
return np.argsort(self.predictor.predict(feed_dict))[::-1]
```

But, current implementation returns an array if predicted labels with ascending order.
Moreover, It returns the result in backward.
