### PR TITLE
tf.concat arguments reordered in time_distributed and some examples

### DIFF
--- a/examples/basics/weights_loading_scope.py
+++ b/examples/basics/weights_loading_scope.py
@@ -103,7 +103,7 @@ class Model12(object):
         with tf.variable_scope("scope2") as scope:
             net_dnn = Model2.make_core_network(inputs)	# shape (?, 10)
 
-        network = tf.concat(1, [net_conv, net_dnn], name="concat")	# shape (?, 20)
+        network = tf.concat([net_conv, net_dnn], 1, name="concat")	# shape (?, 20)
         network = tflearn.fully_connected(network, 10, activation="softmax")
         network = regression(network, optimizer='adam', learning_rate=0.01,
                              loss='categorical_crossentropy', name='target')

--- a/examples/others/recommender_wide_and_deep.py
+++ b/examples/others/recommender_wide_and_deep.py
@@ -239,7 +239,7 @@ class TFLearnWideAndDeep(object):
                 print ("    %s_embed = %s" % (cc, cc_embed_var[cc]))
             flat_vars.append(tf.squeeze(cc_embed_var[cc], squeeze_dims=[1], name="%s_squeeze" % cc))
 
-        network = tf.concat(1, [wide_inputs] + flat_vars, name="deep_concat")
+        network = tf.concat([wide_inputs] + flat_vars, 1, name="deep_concat")
         for k in range(len(n_nodes)):
             network = tflearn.fully_connected(network, n_nodes[k], activation="relu", name="deep_fc%d" % (k+1))
             if use_dropout:

--- a/tflearn/layers/core.py
+++ b/tflearn/layers/core.py
@@ -644,4 +644,4 @@ def time_distributed(incoming, fn, args=None, scope=None):
       x = map(lambda t: tf.reshape(t, [-1, 1]+utils.get_incoming_shape(t)[1:]), x)
     except:
       x = list(map(lambda t: tf.reshape(t, [-1, 1]+utils.get_incoming_shape(t)[1:]), x))
-    return tf.concat(1, x)
+    return tf.concat(x, 1)


### PR DESCRIPTION
Concat function was changed in tensorflow1.0.

> keyword argument concat_dim should be renamed to axis
> arguments have been reordered to tf.concat(values, axis, name='concat').

Arguments reordered in function "concat" (tf.concat(x, axis=1)) will fix bug in time_distributed layer.