### PR TITLE
Fix error message

### DIFF
--- a/tflearn/layers/estimator.py
+++ b/tflearn/layers/estimator.py
@@ -124,7 +124,7 @@ def regression(incoming, placeholder=None, optimizer='adam',
         try:
             optimizer, step_tensor = optimizer(learning_rate)
         except Exception as e:
-            print(e.message)
+            print(str(e))
             print("Reminder: Custom Optimizer function must return (optimizer, "
                   "step_tensor) and take one argument: 'learning_rate'. "
                   "Note that returned step_tensor can be 'None' if no decay.")
@@ -153,9 +153,9 @@ def regression(incoming, placeholder=None, optimizer='adam',
             try:
                 metric = metric(incoming, placeholder, inputs)
             except Exception as e:
-                print(e.message)
+                print(str(e))
                 print('Reminder: Custom metric function arguments must be '
-                      'define as follow: custom_metric(y_pred, y_true, x).')
+                      'defined as: custom_metric(y_pred, y_true, x).')
                 exit()
         elif not isinstance(metric, tf.Tensor):
             raise ValueError("Invalid Metric type.")
@@ -168,9 +168,9 @@ def regression(incoming, placeholder=None, optimizer='adam',
         try:
             loss = loss(incoming, placeholder)
         except Exception as e:
-            print(e.message)
-            print('Reminder: Custom loss function arguments must be define as '
-                  'follow: custom_loss(y_pred, y_true).')
+            print(str(e))
+            print('Reminder: Custom loss function arguments must be defined as: '
+                  'custom_loss(y_pred, y_true).')
             exit()
     elif not isinstance(loss, tf.Tensor):
         raise ValueError("Invalid Loss type.")


### PR DESCRIPTION
The `message` attribute for exceptions has been deprecated.

Without this commit, calling `regression` with a loss function with three arguments instead of two gives

```
Traceback (most recent call last):
  File "/home/me/.local/lib/python3.4/site-packages/tflearn/layers/estimator.py", line 169, in regression
    loss = loss(incoming, placeholder)
TypeError: sparsity_loss() missing 1 required positional argument: 'a'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.4/runpy.py", line 170, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.4/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/me/storm2/src/neuralnetworks/autoencoder3d.py", line 100, in <module>
    models = train(X, Y, X_test, Y_test)
  File "/home/me/storm2/src/neuralnetworks/autoencoder3d.py", line 74, in train
    metric=None)
  File "/home/me/.local/lib/python3.4/site-packages/tflearn/layers/estimator.py", line 171, in regression
    print(e.message)
AttributeError: 'TypeError' object has no attribute 'message'
```

With the fix, it looks like
```
sparsity_loss() missing 1 required positional argument: 'a'
Reminder: Custom loss function arguments must be defined as: custom_loss(y_pred, y_true).
```

I also improved the wording a bit.