### PR TITLE
Update utils.py

### DIFF
--- a/tflearn/utils.py
+++ b/tflearn/utils.py
@@ -392,7 +392,7 @@ def autoformat_kernel_2d(strides):
 def autoformat_filter_conv2d(fsize, in_depth, out_depth):
     if isinstance(fsize,int):
         return [fsize, fsize, in_depth, out_depth]
-    elif isinstance(fsize, (tuple, list)):
+    elif isinstance(fsize, (tuple, list, tf.TensorShape)):
         if len(fsize) == 2:
             return [fsize[0], fsize[1], in_depth, out_depth]
         else:


### PR DESCRIPTION
autoformat_filter_conv2d should support TenshorShape for filter size fsize.
Most probably  similar fix is required in autoformat_filter_conv3d .