### PR TITLE
Fixing time_distributed layer

### DIFF
--- a/tflearn/layers/core.py
+++ b/tflearn/layers/core.py
@@ -640,8 +640,6 @@ def time_distributed(incoming, fn, args=None, scope=None):
              for i in range(timestep)]
     else:
         x = [fn(x[i], *args) for i in range(timestep)]
-    try:
-      x = map(lambda t: tf.reshape(t, [-1, 1]+utils.get_incoming_shape(t)[1:]), x)
-    except:
-      x = list(map(lambda t: tf.reshape(t, [-1, 1]+utils.get_incoming_shape(t)[1:]), x))
+
+    x = list(map(lambda t: tf.reshape(t, [-1, 1]+utils.get_incoming_shape(t)[1:]), x))
     return tf.concat(x, 1)


### PR DESCRIPTION
tf.concat does not support map object anymore, the only way to pass the input into the tf.concat function is to use list(map()).

Therefore, the previous try statement should be depreciated in order to prevent the issue happened in #733