### PR TITLE
Fix bug for loading CIFAR-10 dataset

### DIFF
--- a/tflearn/datasets/cifar10.py
+++ b/tflearn/datasets/cifar10.py
@@ -23,8 +23,7 @@ def load_data(dirname="cifar-10-batches-py", one_hot=False):
     X_train = []
     Y_train = []
 
-    if dirname != 'cifar-10-batches-py':
-        dirname = os.path.join(dirname, 'cifar-10-batches-py')
+    dirname = os.path.join(dirname, 'cifar-10-batches-py')
 
     for i in range(1, 6):
         fpath = os.path.join(dirname, 'data_batch_' + str(i))


### PR DESCRIPTION
When I load CIFAR-10 by default, the variable "dirname" is wrong.

when we try it with specified path "data" for the dataset's directory,
"load_data('data')" makes following tree, and it makes "dirname" to be "data/cifar-10-batches-py/"

project_root/
|- test.ipynb
|- data/
|    |- cifar-10-batches-py.tar.gz
|    |- cifar-10-batches-py/
|    |    |- data_batch_1
|    |    |- ...


but if I use default value for the path,
"dirname" is "cifar-10-batches-py/" but should be "cifar-10-batches-py/cifar-10-batches-py/" after line 26.
because the tree in the project directory is,

project_root/
|- test.ipynb
|- cifar-10-batches-py/
|    |- cifar-10-batches-py.tar.gz
|    |- cifar-10-batches-py/
|    |    |- data_batch_1
|    |    |- ...


