### PR TITLE
Fix Leaky ReLU activation

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -39,5 +39,25 @@ class TestActivations(unittest.TestCase):
             self.assertAlmostEqual(sess.run(f(x), feed_dict={x:-0.25}),
                 -0.2449, places=TestActivations.PLACES)
 
+    def test_leaky_relu(self):
+        f = lambda x: tflearn.leaky_relu(x, alpha=0.2)
+        x = tf.placeholder(tf.float32, shape=())
+
+        with tf.Session() as sess:
+            # Case 1
+            self.assertEqual(sess.run(f(x), feed_dict={x:0}), 0)
+
+            # Case 2
+            self.assertAlmostEqual(sess.run(f(x), feed_dict={x:1}),
+                1, places=TestActivations.PLACES)
+
+            # Case 3
+            self.assertAlmostEqual(sess.run(f(x), feed_dict={x:-1}),
+                -0.2, places=TestActivations.PLACES)
+
+            # Case 4
+            self.assertAlmostEqual(sess.run(f(x), feed_dict={x:-5}),
+                -1, places=TestActivations.PLACES)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tflearn/activations.py
+++ b/tflearn/activations.py
@@ -172,8 +172,8 @@ def leaky_relu(x, alpha=0.1, name="LeakyReLU"):
     """
 
     with tf.name_scope(name) as scope:
-        x = tf.nn.relu(x)
         m_x = tf.nn.relu(-x)
+        x = tf.nn.relu(x)
         x -= alpha * m_x
 
     x.scope = scope


### PR DESCRIPTION
There is a bug in the `activations.leaky_relu` function: as the first line of the implementation starts with `x = tf.nn.relu(x)`, negative values of `x` become lost and unreachable, making the function act like an ordinary ReLU. This PR fixes the bug by swapping the order of operations.

I've also added a unit test for `leaky_relu`, to make sure that it works.