### PR TITLE
Fix tflearn.activation on callable object

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -59,5 +59,35 @@ class TestActivations(unittest.TestCase):
             self.assertAlmostEqual(sess.run(f(x), feed_dict={x:-5}),
                 -1, places=TestActivations.PLACES)
 
+    def test_apply_activation(self):
+        lrelu_02 = lambda x: tflearn.leaky_relu(x, alpha=0.2)
+        x = tf.constant(-0.25, tf.float32)
+
+        with tf.Session() as sess:
+            # Case 1: 'linear'
+            self.assertEqual(
+                sess.run(tflearn.activation(x, 'linear')),
+                -0.25)
+
+            # Case 2: 'relu'
+            self.assertEqual(
+                sess.run(tflearn.activation(x, 'relu')),
+                0)
+
+            # Case 3: 'leaky_relu'
+            self.assertAlmostEqual(
+                sess.run(tflearn.activation(x, 'leaky_relu')),
+                -0.025, places=TestActivations.PLACES)
+
+            # Case 4: 'tanh'
+            self.assertAlmostEqual(
+                sess.run(tflearn.activation(x, 'tanh')),
+                -0.2449, places=TestActivations.PLACES)
+
+            # Case 5: lrelu_02 (callable)
+            self.assertAlmostEqual(
+                sess.run(tflearn.activation(x, lrelu_02)),
+                -0.05, places=TestActivations.PLACES)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tflearn/layers/core.py
+++ b/tflearn/layers/core.py
@@ -338,7 +338,7 @@ def activation(incoming, activation='linear', name='activation'):
 
     if isinstance(activation, str):
         x = activations.get(activation)(incoming)
-    elif hasattr(incoming, '__call__'):
+    elif hasattr(activation, '__call__'):
         x = activation(incoming)
     else:
         raise ValueError('Unknown activation type.')


### PR DESCRIPTION
This PR fixes another bug that prevents `tflearn.activation` from accepting a callable object (such as a function) as  the activation argument.

I've added a test batch for this function as well.