### PR TITLE
Fix function to_categorical in data_utils.py

### DIFF
--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -7,6 +7,7 @@ import numpy as np
 from PIL import Image
 import pickle
 import csv
+import warnings
 
 """
 Preprocessing provides some useful functions to preprocess data before
@@ -36,6 +37,12 @@ def to_categorical(y, nb_classes):
 
     """
     y = np.asarray(y, dtype='int32')
+    # high dimensional array warning
+    if len(y.shape) > 2:
+        warnings.warn('{}-dimensional array is used as input array.'.format(len(y.shape)), stacklevel=2)
+    # flatten high dimensional array
+    if len(y.shape) > 1:
+        y = y.reshape(-1)
     if not nb_classes:
         nb_classes = np.max(y)+1
     Y = np.zeros((len(y), nb_classes))


### PR DESCRIPTION
The asarray function of numpy will keep ndarray's shape, so the original to_categorical function cannot give right result when y is a ndarray with 2-dimension or more. A reshape function is added for changing ndarray to 1-d array. And add a warning when the input array is 3-dimension or more.