### PR TITLE
Fix `bidirectional_rnn` with TF >= 1.2 (resolves #818)

### DIFF
--- a/tflearn/layers/recurrent.py
+++ b/tflearn/layers/recurrent.py
@@ -5,12 +5,13 @@ import logging
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.ops import array_ops
+from tensorflow.python.ops.rnn import static_bidirectional_rnn as _brnn
 try:
-    from tensorflow.python.ops.rnn import rnn_cell_impl as _rnn_cell, dynamic_rnn as _drnn, static_rnn as _rnn, bidirectional_dynamic_rnn as _brnn
+    from tensorflow.python.ops.rnn import rnn_cell_impl as _rnn_cell, dynamic_rnn as _drnn, static_rnn as _rnn
     core_rnn_cell = _rnn_cell
 except:
     # Fix for TF 1.1.0 and under
-    from tensorflow.contrib.rnn.python.ops.core_rnn import static_rnn as _rnn, static_bidirectional_rnn as _brnn
+    from tensorflow.contrib.rnn.python.ops.core_rnn import static_rnn as _rnn
     from tensorflow.python.ops.rnn import rnn_cell_impl as _rnn_cell, dynamic_rnn as _drnn
     from tensorflow.contrib.rnn.python.ops import core_rnn_cell
 

--- a/tflearn/layers/recurrent.py
+++ b/tflearn/layers/recurrent.py
@@ -5,13 +5,12 @@ import logging
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.ops import array_ops
-from tensorflow.python.ops.rnn import static_bidirectional_rnn as _brnn
 try:
-    from tensorflow.python.ops.rnn import rnn_cell_impl as _rnn_cell, dynamic_rnn as _drnn, static_rnn as _rnn
+    from tensorflow.python.ops.rnn import rnn_cell_impl as _rnn_cell, dynamic_rnn as _drnn, static_rnn as _rnn, static_bidirectional_rnn as _brnn
     core_rnn_cell = _rnn_cell
 except:
     # Fix for TF 1.1.0 and under
-    from tensorflow.contrib.rnn.python.ops.core_rnn import static_rnn as _rnn
+    from tensorflow.contrib.rnn.python.ops.core_rnn import static_rnn as _rnn, static_bidirectional_rnn as _brnn
     from tensorflow.python.ops.rnn import rnn_cell_impl as _rnn_cell, dynamic_rnn as _drnn
     from tensorflow.contrib.rnn.python.ops import core_rnn_cell
 


### PR DESCRIPTION
`bidirectional_dynamic_rnn` is not compatible with TFLearn's current bidirectional implementation, so throws an error with TF >= 1.2.0. (Resolves #818)