### PR TITLE
Fix problem with excluding training ops

### DIFF
--- a/tflearn/helpers/trainer.py
+++ b/tflearn/helpers/trainer.py
@@ -237,10 +237,9 @@ class Trainer(object):
 
         original_train_ops = list(self.train_ops)
         # Remove excluded train_ops
-        for t in self.train_ops:
-            if excl_trainops and t in excl_trainops:
-                self.train_ops.remove(t)
-
+        if excl_trainops:
+            self.train_ops = list(filter(lambda a: a not in excl_trainops, self.train_ops))
+	    
         # shuffle is an override for simplicty, it will overrides every
         # training op batch shuffling
         if isinstance(shuffle_all, bool):


### PR DESCRIPTION
I've found a problem on a line 240 of tflearn/helpers/trainer.py where i've made changes.
The problem is that a cycle, where program removes excluded training operations from actual ones, it doesn't remove all training operations that must be excluded. I'll try to explain this cycle on similar task of removing numbers from an array. Let's see:
`
a = [2, 2, 2, 2, 2, 2, 2 , 2, 2, 2 ,2 ,2 , 2]

print(a)

for t in a:
    if t == 2:
        a.remove(t)
    
print(a)
`
This is a similar cycle that removes number 2 from array instead of excluded trainops. You think that it'll remove all 2 and resulting array a will be empty. But if you run this code you'll see, that it six numbers 2 in your array left!
It's happen so, because, ii seems to me, Python's iterator have some attachements to index of element instead of element itself. How it's hapenning:
first iteration:
elements | a b c d
indexes   | 0 1 2 3
you here | ^

cycle takes zero element from an array. Element 'a' removed
second iteration
elements | b c d
old ind.    | 1 2 3
indexes   | 0 1 2
you here |    ^

iterator takes element with index 1, that have a sense if array is still similar. But as first item was removed, indexes of elements has changed, and now element 1 is a an element 2 from previous iteration. 
That way your cycle doesn't always pass over all items, while there are training operations to exclude. I've found this error when tried to use on my graph three different trainops, that should run separately in different training steps.
