### PR TITLE
fix selu activation function

### DIFF
--- a/tflearn/activations.py
+++ b/tflearn/activations.py
@@ -303,4 +303,4 @@ def selu(x):
     """
     alpha = 1.6732632423543772848170429916717
     scale = 1.0507009873554804934193349852946
-    return scale * tf.nn.elu(x, alpha)
+    return scale*tf.where(x>=0.0, x, alpha*tf.nn.elu(x))


### PR DESCRIPTION
This problem is mentioned in the #845.
The v1.2 implementation of `tf.nn.elu` does not include the parameter alpha.

acording to : https://www.tensorflow.org/versions/master/api_docs/python/tf/nn/elu.
`tf.nn.elu` just do
> Computes exponential linear: exp(features) - 1 if < 0, features otherwise


