### PR TITLE
Fix Grayscale Image Shape

### DIFF
--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -833,7 +833,7 @@ class ImagePreloader(Preloader):
             img = convert_color(img, 'L')
         img = pil_to_nparray(img)
         if grayscale:
-            img = np.reshape(img, (*img.shape, 1))
+            img = np.reshape(img, img.shape + (1,)))
         if normalize:
             img /= 255.
         return img

--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -832,6 +832,8 @@ class ImagePreloader(Preloader):
         if grayscale:
             img = convert_color(img, 'L')
         img = pil_to_nparray(img)
+        if grayscale:
+            img = np.reshape(img, (*img.shape, 1))
         if normalize:
             img /= 255.
         return img

--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -833,7 +833,7 @@ class ImagePreloader(Preloader):
             img = convert_color(img, 'L')
         img = pil_to_nparray(img)
         if grayscale:
-            img = np.reshape(img, img.shape + (1,)))
+            img = np.reshape(img, img.shape + (1,))
         if normalize:
             img /= 255.
         return img


### PR DESCRIPTION
When using grayscale images, making the shape [None, width, height, 1] will allow you to use it directly with an input_layer, since it's a 4-D tensor, as apposed to [None, width, height]. Color images are 4-D by default ([None, width, height, 3])

I ran into this problem when trying to do the following:

`...`
`X, Y = image_preloader(dataset_file, image_shape=(75, 90), mode='file', categorical_labels=True,` `normalize=True, grayscale=True)`

`# Building deep neural network`
`network = tflearn.input_data(shape=[None, 90, 75, 1]) #Can't be [None, 90,75], because must be 4-D` `tensor`
`...`

Without the change, tensorflow raises an exception that the tensor for the images needs to be 4-D as well. This is a pretty simple fix for that