### PR TITLE
When using the image_preloader the images can be loaded from an URL.

### DIFF
--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -8,6 +8,9 @@ from PIL import Image
 import pickle
 import csv
 import warnings
+from urllib.parse import urlparse
+from io import BytesIO
+from urllib import request
 
 """
 Preprocessing provides some useful functions to preprocess data before
@@ -538,7 +541,15 @@ def image_preloader(target_path, image_shape, mode='file', normalize=True,
 
 def load_image(in_image):
     """ Load an image, returns PIL.Image. """
-    img = Image.open(in_image)
+    # if the path appears to be an URL
+    if urlparse(in_image).scheme in ('http', 'https',):
+        # set up the byte stream
+        img_stream = BytesIO(request.urlopen(in_image).read())
+        # and read in as PIL image
+        img = Image.open(img_stream)
+    else:
+        # else use it as local file path
+        img = Image.open(in_image)
     return img
 
 


### PR DESCRIPTION
This is a contribution for #866 to allow the usage of URLs as image source when using an image_preloader.

This implementation uses the Python3 versions of the IO and urllib modules.

Currently every image path is parsed by urlparse to see if it is a URL or local file path. 

Another possibility would be to configure the image preloader at instantiation for a mode (e.g. use only internet images, use only local files or a mixed mode) to disable the parsing e.g. if only local files are used.

![imload_lena](https://user-images.githubusercontent.com/1067159/29407084-6f4b949c-8343-11e7-9b40-65c09b22ae8a.PNG)
