### PR TITLE
Change of residual_bottleneck

### DIFF
--- a/tflearn/layers/conv.py
+++ b/tflearn/layers/conv.py
@@ -1567,8 +1567,8 @@ def residual_bottleneck(incoming, nb_blocks, bottleneck_size, out_channels,
                                   [[0, 0], [0, 0], [0, 0], [ch, ch]])
                 in_channels = out_channels
 
-                resnet = resnet + identity
-                resnet = tflearn.activation(resnet, activation)
+            resnet = resnet + identity
+            resnet = tflearn.activation(resnet, activation)
 
     return resnet
 


### PR DESCRIPTION
I think there is a small mistake in the last several steps in the source code of residual_bottleneck.
I think the last two lines codes should not be included in the condition of  in_channels!= out_channels