### PR TITLE
Fixes the seq2seq example

### DIFF
--- a/examples/nlp/seq2seq_example.py
+++ b/examples/nlp/seq2seq_example.py
@@ -14,7 +14,7 @@ import json
 import numpy as np
 import tensorflow as tf
 
-from tensorflow.python.ops import seq2seq
+from tensorflow.contrib.legacy_seq2seq.python.ops import seq2seq
 from tensorflow.python.ops import rnn_cell
 
 #-----------------------------------------------------------------------------

--- a/tflearn/summaries.py
+++ b/tflearn/summaries.py
@@ -179,6 +179,11 @@ def get_value_from_summary_string(tag, summary_str):
         `Exception` if tag not found.
 
     """
+
+    # Compatibility hotfix for the seq2seq example
+    if tag == u'acc:0/':
+        tag = u'acc_0/'
+
     # Fix for TF 0.12
     if tag[-1] == '/':
         tag = tag[:-1]


### PR DESCRIPTION
The seq2seq example in TFLearn does not run with the latest versions of TFLearn and Tensorflow. This PR hotfixes the problems so that the example runs. There are two changes:

In the example itself, we point to the legacy seq2seq class in Tensorflow.

In summaries.py, the format of the tag has changed in Tensorflow; this breaks the seq2seq example, so we hotfix the particular tag that's a problem in the seq2seq example.