### PR TITLE
Update the to_categorical in the data_utils.py

### DIFF
--- a/docs/templates/examples.md
+++ b/docs/templates/examples.md
@@ -29,8 +29,10 @@
 - [Highway Convolutional Network](https://github.com/tflearn/tflearn/blob/master/examples/images/convnet_highway_mnist.py). Highway Convolutional Network implementation for classifying MNIST dataset.
 - [Residual Network (MNIST)](https://github.com/tflearn/tflearn/blob/master/examples/images/residual_network_mnist.py). A bottleneck residual network applied to MNIST classification task.
 - [Residual Network (CIFAR-10)](https://github.com/tflearn/tflearn/blob/master/examples/images/residual_network_cifar10.py). A residual network applied to CIFAR-10 classification task.
-- [ResNeXt (CIFAR-10)](https://github.com/tflearn/tflearn/blob/master/examples/images/resnext_cifar10.py). Aggregated residual transformations network (ResNeXt) applied to CIFAR-10 classification task.
+- [ResNeXt](https://github.com/tflearn/tflearn/blob/master/examples/images/resnext_cifar10.py). Aggregated residual transformations network (ResNeXt) applied to CIFAR-10 classification task.
+- [DenseNet](https://github.com/tflearn/tflearn/blob/master/examples/images/densenet.py). A densely connected convolutional network applied to CIFAR-10 classification task.
 - [Google Inception (v3)](https://github.com/tflearn/tflearn/blob/master/examples/images/googlenet.py). Google's Inception v3 network applied to Oxford Flowers 17 classification task.
+
 ### Unsupervised
 - [Auto Encoder](https://github.com/tflearn/tflearn/blob/master/examples/images/autoencoder.py). An auto encoder applied to MNIST handwritten digits.
 - [Variational Auto Encoder](https://github.com/tflearn/tflearn/blob/master/examples/images/variational_autoencoder.py). A Variational Auto Encoder (VAE) trained to generate digit images.

--- a/docs/templates/getting_started.md
+++ b/docs/templates/getting_started.md
@@ -45,7 +45,7 @@ File | Layers
 
 ### Built-in Operations
 
-Besides layers concept, TFLearn also provides many different ops to be used when building a neural network. These ops are firstly mean to be part of the above 'layers' arguments, but they can also be used independently in any other Tensorflow graph for convenience. In practice, just providing the op name as argument is enough (such as activation='relu' or regularizer='L2' for conv_2d), but a function can also be provided for further customization.
+Besides layers concept, TFLearn also provides many different ops to be used when building a neural network. These ops are firstly meant to be part of the above 'layers' arguments, but they can also be used independently in any other Tensorflow graph for convenience. In practice, just providing the op name as argument is enough (such as activation='relu' or regularizer='L2' for conv_2d), but a function can also be provided for further customization.
 
 File | Ops
 -----|----

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,7 +29,8 @@
 - [Highway Convolutional Network](https://github.com/tflearn/tflearn/blob/master/examples/images/convnet_highway_mnist.py). Highway Convolutional Network implementation for classifying MNIST dataset.
 - [Residual Network (MNIST)](https://github.com/tflearn/tflearn/blob/master/examples/images/residual_network_mnist.py). A bottleneck residual network applied to MNIST classification task.
 - [Residual Network (CIFAR-10)](https://github.com/tflearn/tflearn/blob/master/examples/images/residual_network_cifar10.py). A residual network applied to CIFAR-10 classification task.
-- [ResNeXt (CIFAR-10)](https://github.com/tflearn/tflearn/blob/master/examples/images/resnext_cifar10.py). Aggregated residual transformations network (ResNeXt) applied to CIFAR-10 classification task.
+- [ResNeXt](https://github.com/tflearn/tflearn/blob/master/examples/images/resnext_cifar10.py). Aggregated residual transformations network (ResNeXt) applied to CIFAR-10 classification task.
+- [DenseNet](https://github.com/tflearn/tflearn/blob/master/examples/images/densenet.py). A densely connected convolutional network applied to CIFAR-10 classification task.
 - [Google Inception (v3)](https://github.com/tflearn/tflearn/blob/master/examples/images/googlenet.py). Google's Inception v3 network applied to Oxford Flowers 17 classification task.
 ### Unsupervised
 - [Auto Encoder](https://github.com/tflearn/tflearn/blob/master/examples/images/autoencoder.py). An auto encoder applied to MNIST handwritten digits.

--- a/examples/basics/use_dask.py
+++ b/examples/basics/use_dask.py
@@ -19,8 +19,8 @@ from tflearn.layers.estimator import *
 # Load CIFAR-10 Dataset
 from tflearn.datasets import cifar10
 (X, Y), (X_test, Y_test) = cifar10.load_data()
-Y = to_categorical(Y, 10)
-Y_test = to_categorical(Y_test, 10)
+Y = to_categorical(Y)
+Y_test = to_categorical(Y_test)
 
 # Create DASK array using numpy arrays
 # (Note that it can work with HDF5 Dataset too)

--- a/examples/basics/use_hdf5.py
+++ b/examples/basics/use_hdf5.py
@@ -19,8 +19,8 @@ from tflearn.layers.estimator import regression
 # CIFAR-10 Dataset
 from tflearn.datasets import cifar10
 (X, Y), (X_test, Y_test) = cifar10.load_data()
-Y = to_categorical(Y, 10)
-Y_test = to_categorical(Y_test, 10)
+Y = to_categorical(Y)
+Y_test = to_categorical(Y_test)
 
 # Create a hdf5 dataset from CIFAR-10 numpy array
 import h5py

--- a/examples/extending_tensorflow/summaries.py
+++ b/examples/extending_tensorflow/summaries.py
@@ -74,11 +74,13 @@ with tf.Graph().as_default():
         return x
 
     net = dnn(X)
-    loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(net, Y))
-    optimizer = tf.train.GradientDescentOptimizer(learning_rate=0.1)
-    accuracy = tf.reduce_mean(
-        tf.cast(tf.equal(tf.argmax(net, 1), tf.argmax(Y, 1)), tf.float32),
-        name="acc")
+        
+    with tf.name_scope('Summaries'):
+        loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(logits=net,labels=Y))
+        optimizer = tf.train.GradientDescentOptimizer(learning_rate=0.1)
+        accuracy = tf.reduce_mean(
+            tf.cast(tf.equal(tf.argmax(net, 1), tf.argmax(Y, 1)), tf.float32),
+            name="acc")
 
     # construct two varaibles to add as additional "valiation monitors"
     # these varaibles are evaluated each time validation happens (eg at a snapshot)
@@ -92,11 +94,10 @@ with tf.Graph().as_default():
     with tf.name_scope('CustomMonitor'):
         test_var = tf.reduce_sum(tf.cast(net, tf.float32), name="test_var")
         test_const = tf.constant(32.0, name="custom_constant")
-
-    # Define a train op
+        # Define a train op
     trainop = tflearn.TrainOp(loss=loss, optimizer=optimizer,
-                              validation_monitors=[test_var, test_const],
-                              metric=accuracy, batch_size=128)
+                            validation_monitors=[test_var, test_const],
+                            metric=accuracy, batch_size=128)
 
     # Tensorboard logs stored in /tmp/tflearn_logs/. Using verbose level 2.
     trainer = tflearn.Trainer(train_ops=trainop,

--- a/examples/images/convnet_cifar10.py
+++ b/examples/images/convnet_cifar10.py
@@ -23,8 +23,8 @@ from tflearn.data_augmentation import ImageAugmentation
 from tflearn.datasets import cifar10
 (X, Y), (X_test, Y_test) = cifar10.load_data()
 X, Y = shuffle(X, Y)
-Y = to_categorical(Y, 10)
-Y_test = to_categorical(Y_test, 10)
+Y = to_categorical(Y)
+Y_test = to_categorical(Y_test)
 
 # Real-time data preprocessing
 img_prep = ImagePreprocessing()

--- a/examples/images/dcgan.py
+++ b/examples/images/dcgan.py
@@ -99,15 +99,15 @@ disc_noise = np.random.uniform(-1., 1., size=[total_samples, z_dim])
 # Prepare target data to feed to the discriminator (0: fake image, 1: real image)
 y_disc_fake = np.zeros(shape=[total_samples])
 y_disc_real = np.ones(shape=[total_samples])
-y_disc_fake = tflearn.data_utils.to_categorical(y_disc_fake, 2)
-y_disc_real = tflearn.data_utils.to_categorical(y_disc_real, 2)
+y_disc_fake = tflearn.data_utils.to_categorical(y_disc_fake)
+y_disc_real = tflearn.data_utils.to_categorical(y_disc_real)
 
 # Prepare input data to feed to the stacked generator/discriminator
 gen_noise = np.random.uniform(-1., 1., size=[total_samples, z_dim])
 # Prepare target data to feed to the discriminator
 # Generator tries to fool the discriminator, thus target is 1 (e.g. real images)
 y_gen = np.ones(shape=[total_samples])
-y_gen = tflearn.data_utils.to_categorical(y_gen, 2)
+y_gen = tflearn.data_utils.to_categorical(y_gen)
 
 # Start training, feed both noise and real images.
 gan.fit(X_inputs={'input_gen_noise': gen_noise,

--- a/examples/images/densenet.py
+++ b/examples/images/densenet.py
@@ -27,8 +27,8 @@ nb_layers = int((L - 4) / 3)
 # Data loading
 from tflearn.datasets import cifar10
 (X, Y), (testX, testY) = cifar10.load_data()
-Y = tflearn.data_utils.to_categorical(Y, 10)
-testY = tflearn.data_utils.to_categorical(testY, 10)
+Y = tflearn.data_utils.to_categorical(Y)
+testY = tflearn.data_utils.to_categorical(testY)
 
 # Real-time data preprocessing
 img_prep = tflearn.ImagePreprocessing()

--- a/examples/images/densenet.py
+++ b/examples/images/densenet.py
@@ -51,7 +51,7 @@ net = tflearn.global_avg_pool(net)
 
 # Regression
 net = tflearn.fully_connected(net, 10, activation='softmax')
-opt = tflearn.SGD(0.1, lr_decay=0.1, decay_step=32000, staircase=True)
+opt = tflearn.Nesterov(0.1, lr_decay=0.1, decay_step=32000, staircase=True)
 net = tflearn.regression(net, optimizer=opt,
                          loss='categorical_crossentropy')
 # Training

--- a/examples/images/densenet.py
+++ b/examples/images/densenet.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+""" Densely Connected Convolutional Networks.
+
+Applying a 'DenseNet' to CIFAR-10 Dataset classification task.
+
+References:
+    - G. Huang, Z. Liu, K. Q. Weinberger, L. van der Maaten. Densely Connected 
+        Convolutional Networks, 2016.
+
+Links:
+    - [Densely Connected Convolutional Networks](https://arxiv.org/abs/1608.06993)
+    - [CIFAR-10 Dataset](https://www.cs.toronto.edu/~kriz/cifar.html)
+
+"""
+
+from __future__ import division, print_function, absolute_import
+
+import tflearn
+
+# Growth Rate (12, 16, 32, ...)
+k = 12
+
+# Depth (40, 100, ...)
+L = 40
+nb_layers = int((L - 4) / 3)
+
+# Data loading
+from tflearn.datasets import cifar10
+(X, Y), (testX, testY) = cifar10.load_data()
+Y = tflearn.data_utils.to_categorical(Y, 10)
+testY = tflearn.data_utils.to_categorical(testY, 10)
+
+# Real-time data preprocessing
+img_prep = tflearn.ImagePreprocessing()
+img_prep.add_featurewise_zero_center(per_channel=True)
+
+# Real-time data augmentation
+img_aug = tflearn.ImageAugmentation()
+img_aug.add_random_flip_leftright()
+img_aug.add_random_crop([32, 32], padding=4)
+
+# Building Residual Network
+net = tflearn.input_data(shape=[None, 32, 32, 3],
+                         data_preprocessing=img_prep,
+                         data_augmentation=img_aug)
+net = tflearn.conv_2d(net, 16, 3, regularizer='L2', weight_decay=0.0001)
+net = tflearn.densenet_block(net, nb_layers, k)
+net = tflearn.densenet_block(net, nb_layers, k)
+net = tflearn.densenet_block(net, nb_layers, k)
+net = tflearn.global_avg_pool(net)
+
+# Regression
+net = tflearn.fully_connected(net, 10, activation='softmax')
+opt = tflearn.SGD(0.1, lr_decay=0.1, decay_step=32000, staircase=True)
+net = tflearn.regression(net, optimizer=opt,
+                         loss='categorical_crossentropy')
+# Training
+model = tflearn.DNN(net, checkpoint_path='model_densenet_cifar10',
+                    max_checkpoints=10, tensorboard_verbose=0,
+                    clip_gradients=0.)
+
+model.fit(X, Y, n_epoch=200, validation_set=(testX, testY),
+          snapshot_epoch=False, snapshot_step=500,
+          show_metric=True, batch_size=128, shuffle=True,
+          run_id='densenet_cifar10')

--- a/examples/images/googlenet.py
+++ b/examples/images/googlenet.py
@@ -23,38 +23,37 @@ from tflearn.layers.estimator import regression
 import tflearn.datasets.oxflower17 as oxflower17
 X, Y = oxflower17.load_data(one_hot=True, resize_pics=(227, 227))
 
-
 network = input_data(shape=[None, 227, 227, 3])
-conv1_7_7 = conv_2d(network, 64, 7, strides=2, activation='relu', name = 'conv1_7_7_s2')
-pool1_3_3 = max_pool_2d(conv1_7_7, 3,strides=2)
+conv1_7_7 = conv_2d(network, 64, 7, strides=2, activation='relu', name='conv1_7_7_s2')
+pool1_3_3 = max_pool_2d(conv1_7_7, 3, strides=2)
 pool1_3_3 = local_response_normalization(pool1_3_3)
-conv2_3_3_reduce = conv_2d(pool1_3_3, 64,1, activation='relu',name = 'conv2_3_3_reduce')
-conv2_3_3 = conv_2d(conv2_3_3_reduce, 192,3, activation='relu', name='conv2_3_3')
+conv2_3_3_reduce = conv_2d(pool1_3_3, 64, 1, activation='relu', name='conv2_3_3_reduce')
+conv2_3_3 = conv_2d(conv2_3_3_reduce, 192, 3, activation='relu', name='conv2_3_3')
 conv2_3_3 = local_response_normalization(conv2_3_3)
 pool2_3_3 = max_pool_2d(conv2_3_3, kernel_size=3, strides=2, name='pool2_3_3_s2')
-inception_3a_1_1 = conv_2d(pool2_3_3, 64, 1, activation='relu', name='inception_3a_1_1')
-inception_3a_3_3_reduce = conv_2d(pool2_3_3, 96,1, activation='relu', name='inception_3a_3_3_reduce')
-inception_3a_3_3 = conv_2d(inception_3a_3_3_reduce, 128,filter_size=3,  activation='relu', name = 'inception_3a_3_3')
-inception_3a_5_5_reduce = conv_2d(pool2_3_3,16, filter_size=1,activation='relu', name ='inception_3a_5_5_reduce' )
-inception_3a_5_5 = conv_2d(inception_3a_5_5_reduce, 32, filter_size=5, activation='relu', name= 'inception_3a_5_5')
-inception_3a_pool = max_pool_2d(pool2_3_3, kernel_size=3, strides=1, )
-inception_3a_pool_1_1 = conv_2d(inception_3a_pool, 32, filter_size=1, activation='relu', name='inception_3a_pool_1_1')
 
-# merge the inception_3a__
+# 3a
+inception_3a_1_1 = conv_2d(pool2_3_3, 64, 1, activation='relu', name='inception_3a_1_1')
+inception_3a_3_3_reduce = conv_2d(pool2_3_3, 96, 1, activation='relu', name='inception_3a_3_3_reduce')
+inception_3a_3_3 = conv_2d(inception_3a_3_3_reduce, 128, filter_size=3,  activation='relu', name='inception_3a_3_3')
+inception_3a_5_5_reduce = conv_2d(pool2_3_3, 16, filter_size=1, activation='relu', name='inception_3a_5_5_reduce')
+inception_3a_5_5 = conv_2d(inception_3a_5_5_reduce, 32, filter_size=5, activation='relu', name='inception_3a_5_5')
+inception_3a_pool = max_pool_2d(pool2_3_3, kernel_size=3, strides=1, name='inception_3a_pool')
+inception_3a_pool_1_1 = conv_2d(inception_3a_pool, 32, filter_size=1, activation='relu', name='inception_3a_pool_1_1')
 inception_3a_output = merge([inception_3a_1_1, inception_3a_3_3, inception_3a_5_5, inception_3a_pool_1_1], mode='concat', axis=3)
 
-inception_3b_1_1 = conv_2d(inception_3a_output, 128,filter_size=1,activation='relu', name= 'inception_3b_1_1' )
+# 3b
+inception_3b_1_1 = conv_2d(inception_3a_output, 128, filter_size=1, activation='relu', name='inception_3b_1_1')
 inception_3b_3_3_reduce = conv_2d(inception_3a_output, 128, filter_size=1, activation='relu', name='inception_3b_3_3_reduce')
-inception_3b_3_3 = conv_2d(inception_3b_3_3_reduce, 192, filter_size=3,  activation='relu',name='inception_3b_3_3')
-inception_3b_5_5_reduce = conv_2d(inception_3a_output, 32, filter_size=1, activation='relu', name = 'inception_3b_5_5_reduce')
-inception_3b_5_5 = conv_2d(inception_3b_5_5_reduce, 96, filter_size=5,  name = 'inception_3b_5_5')
+inception_3b_3_3 = conv_2d(inception_3b_3_3_reduce, 192, filter_size=3, activation='relu', name='inception_3b_3_3')
+inception_3b_5_5_reduce = conv_2d(inception_3a_output, 32, filter_size=1, activation='relu', name='inception_3b_5_5_reduce')
+inception_3b_5_5 = conv_2d(inception_3b_5_5_reduce, 96, filter_size=5,  name='inception_3b_5_5')
 inception_3b_pool = max_pool_2d(inception_3a_output, kernel_size=3, strides=1,  name='inception_3b_pool')
-inception_3b_pool_1_1 = conv_2d(inception_3b_pool, 64, filter_size=1,activation='relu', name='inception_3b_pool_1_1')
-
-#merge the inception_3b_*
-inception_3b_output = merge([inception_3b_1_1, inception_3b_3_3, inception_3b_5_5, inception_3b_pool_1_1], mode='concat',axis=3,name='inception_3b_output')
-
+inception_3b_pool_1_1 = conv_2d(inception_3b_pool, 64, filter_size=1, activation='relu', name='inception_3b_pool_1_1')
+inception_3b_output = merge([inception_3b_1_1, inception_3b_3_3, inception_3b_5_5, inception_3b_pool_1_1], mode='concat', axis=3, name='inception_3b_output')
 pool3_3_3 = max_pool_2d(inception_3b_output, kernel_size=3, strides=2, name='pool3_3_3')
+
+# 4a
 inception_4a_1_1 = conv_2d(pool3_3_3, 192, filter_size=1, activation='relu', name='inception_4a_1_1')
 inception_4a_3_3_reduce = conv_2d(pool3_3_3, 96, filter_size=1, activation='relu', name='inception_4a_3_3_reduce')
 inception_4a_3_3 = conv_2d(inception_4a_3_3_reduce, 208, filter_size=3,  activation='relu', name='inception_4a_3_3')
@@ -62,33 +61,29 @@ inception_4a_5_5_reduce = conv_2d(pool3_3_3, 16, filter_size=1, activation='relu
 inception_4a_5_5 = conv_2d(inception_4a_5_5_reduce, 48, filter_size=5,  activation='relu', name='inception_4a_5_5')
 inception_4a_pool = max_pool_2d(pool3_3_3, kernel_size=3, strides=1,  name='inception_4a_pool')
 inception_4a_pool_1_1 = conv_2d(inception_4a_pool, 64, filter_size=1, activation='relu', name='inception_4a_pool_1_1')
-
 inception_4a_output = merge([inception_4a_1_1, inception_4a_3_3, inception_4a_5_5, inception_4a_pool_1_1], mode='concat', axis=3, name='inception_4a_output')
 
-
+# 4b
 inception_4b_1_1 = conv_2d(inception_4a_output, 160, filter_size=1, activation='relu', name='inception_4a_1_1')
 inception_4b_3_3_reduce = conv_2d(inception_4a_output, 112, filter_size=1, activation='relu', name='inception_4b_3_3_reduce')
 inception_4b_3_3 = conv_2d(inception_4b_3_3_reduce, 224, filter_size=3, activation='relu', name='inception_4b_3_3')
 inception_4b_5_5_reduce = conv_2d(inception_4a_output, 24, filter_size=1, activation='relu', name='inception_4b_5_5_reduce')
 inception_4b_5_5 = conv_2d(inception_4b_5_5_reduce, 64, filter_size=5,  activation='relu', name='inception_4b_5_5')
-
 inception_4b_pool = max_pool_2d(inception_4a_output, kernel_size=3, strides=1,  name='inception_4b_pool')
 inception_4b_pool_1_1 = conv_2d(inception_4b_pool, 64, filter_size=1, activation='relu', name='inception_4b_pool_1_1')
-
 inception_4b_output = merge([inception_4b_1_1, inception_4b_3_3, inception_4b_5_5, inception_4b_pool_1_1], mode='concat', axis=3, name='inception_4b_output')
 
-
-inception_4c_1_1 = conv_2d(inception_4b_output, 128, filter_size=1, activation='relu',name='inception_4c_1_1')
+# 4c
+inception_4c_1_1 = conv_2d(inception_4b_output, 128, filter_size=1, activation='relu', name='inception_4c_1_1')
 inception_4c_3_3_reduce = conv_2d(inception_4b_output, 128, filter_size=1, activation='relu', name='inception_4c_3_3_reduce')
 inception_4c_3_3 = conv_2d(inception_4c_3_3_reduce, 256,  filter_size=3, activation='relu', name='inception_4c_3_3')
 inception_4c_5_5_reduce = conv_2d(inception_4b_output, 24, filter_size=1, activation='relu', name='inception_4c_5_5_reduce')
 inception_4c_5_5 = conv_2d(inception_4c_5_5_reduce, 64,  filter_size=5, activation='relu', name='inception_4c_5_5')
-
 inception_4c_pool = max_pool_2d(inception_4b_output, kernel_size=3, strides=1)
 inception_4c_pool_1_1 = conv_2d(inception_4c_pool, 64, filter_size=1, activation='relu', name='inception_4c_pool_1_1')
+inception_4c_output = merge([inception_4c_1_1, inception_4c_3_3, inception_4c_5_5, inception_4c_pool_1_1], mode='concat', axis=3, name='inception_4c_output')
 
-inception_4c_output = merge([inception_4c_1_1, inception_4c_3_3, inception_4c_5_5, inception_4c_pool_1_1], mode='concat', axis=3,name='inception_4c_output')
-
+# 4d
 inception_4d_1_1 = conv_2d(inception_4c_output, 112, filter_size=1, activation='relu', name='inception_4d_1_1')
 inception_4d_3_3_reduce = conv_2d(inception_4c_output, 144, filter_size=1, activation='relu', name='inception_4d_3_3_reduce')
 inception_4d_3_3 = conv_2d(inception_4d_3_3_reduce, 288, filter_size=3, activation='relu', name='inception_4d_3_3')
@@ -96,9 +91,9 @@ inception_4d_5_5_reduce = conv_2d(inception_4c_output, 32, filter_size=1, activa
 inception_4d_5_5 = conv_2d(inception_4d_5_5_reduce, 64, filter_size=5,  activation='relu', name='inception_4d_5_5')
 inception_4d_pool = max_pool_2d(inception_4c_output, kernel_size=3, strides=1,  name='inception_4d_pool')
 inception_4d_pool_1_1 = conv_2d(inception_4d_pool, 64, filter_size=1, activation='relu', name='inception_4d_pool_1_1')
-
 inception_4d_output = merge([inception_4d_1_1, inception_4d_3_3, inception_4d_5_5, inception_4d_pool_1_1], mode='concat', axis=3, name='inception_4d_output')
 
+# 4e
 inception_4e_1_1 = conv_2d(inception_4d_output, 256, filter_size=1, activation='relu', name='inception_4e_1_1')
 inception_4e_3_3_reduce = conv_2d(inception_4d_output, 160, filter_size=1, activation='relu', name='inception_4e_3_3_reduce')
 inception_4e_3_3 = conv_2d(inception_4e_3_3_reduce, 320, filter_size=3, activation='relu', name='inception_4e_3_3')
@@ -106,41 +101,42 @@ inception_4e_5_5_reduce = conv_2d(inception_4d_output, 32, filter_size=1, activa
 inception_4e_5_5 = conv_2d(inception_4e_5_5_reduce, 128,  filter_size=5, activation='relu', name='inception_4e_5_5')
 inception_4e_pool = max_pool_2d(inception_4d_output, kernel_size=3, strides=1,  name='inception_4e_pool')
 inception_4e_pool_1_1 = conv_2d(inception_4e_pool, 128, filter_size=1, activation='relu', name='inception_4e_pool_1_1')
-
-
-inception_4e_output = merge([inception_4e_1_1, inception_4e_3_3, inception_4e_5_5,inception_4e_pool_1_1],axis=3, mode='concat')
-
+inception_4e_output = merge([inception_4e_1_1, inception_4e_3_3, inception_4e_5_5, inception_4e_pool_1_1], axis=3, mode='concat')
 pool4_3_3 = max_pool_2d(inception_4e_output, kernel_size=3, strides=2, name='pool_3_3')
 
-
+# 5a
 inception_5a_1_1 = conv_2d(pool4_3_3, 256, filter_size=1, activation='relu', name='inception_5a_1_1')
 inception_5a_3_3_reduce = conv_2d(pool4_3_3, 160, filter_size=1, activation='relu', name='inception_5a_3_3_reduce')
 inception_5a_3_3 = conv_2d(inception_5a_3_3_reduce, 320, filter_size=3, activation='relu', name='inception_5a_3_3')
 inception_5a_5_5_reduce = conv_2d(pool4_3_3, 32, filter_size=1, activation='relu', name='inception_5a_5_5_reduce')
 inception_5a_5_5 = conv_2d(inception_5a_5_5_reduce, 128, filter_size=5,  activation='relu', name='inception_5a_5_5')
 inception_5a_pool = max_pool_2d(pool4_3_3, kernel_size=3, strides=1,  name='inception_5a_pool')
-inception_5a_pool_1_1 = conv_2d(inception_5a_pool, 128, filter_size=1,activation='relu', name='inception_5a_pool_1_1')
+inception_5a_pool_1_1 = conv_2d(inception_5a_pool, 128, filter_size=1, activation='relu', name='inception_5a_pool_1_1')
+inception_5a_output = merge([inception_5a_1_1, inception_5a_3_3, inception_5a_5_5, inception_5a_pool_1_1], axis=3, mode='concat')
 
-inception_5a_output = merge([inception_5a_1_1, inception_5a_3_3, inception_5a_5_5, inception_5a_pool_1_1], axis=3,mode='concat')
-
-
-inception_5b_1_1 = conv_2d(inception_5a_output, 384, filter_size=1,activation='relu', name='inception_5b_1_1')
+# 5b
+inception_5b_1_1 = conv_2d(inception_5a_output, 384, filter_size=1, activation='relu', name='inception_5b_1_1')
 inception_5b_3_3_reduce = conv_2d(inception_5a_output, 192, filter_size=1, activation='relu', name='inception_5b_3_3_reduce')
-inception_5b_3_3 = conv_2d(inception_5b_3_3_reduce, 384,  filter_size=3,activation='relu', name='inception_5b_3_3')
+inception_5b_3_3 = conv_2d(inception_5b_3_3_reduce, 384,  filter_size=3, activation='relu', name='inception_5b_3_3')
 inception_5b_5_5_reduce = conv_2d(inception_5a_output, 48, filter_size=1, activation='relu', name='inception_5b_5_5_reduce')
-inception_5b_5_5 = conv_2d(inception_5b_5_5_reduce,128, filter_size=5,  activation='relu', name='inception_5b_5_5' )
+inception_5b_5_5 = conv_2d(inception_5b_5_5_reduce, 128, filter_size=5, activation='relu', name='inception_5b_5_5')
 inception_5b_pool = max_pool_2d(inception_5a_output, kernel_size=3, strides=1,  name='inception_5b_pool')
 inception_5b_pool_1_1 = conv_2d(inception_5b_pool, 128, filter_size=1, activation='relu', name='inception_5b_pool_1_1')
 inception_5b_output = merge([inception_5b_1_1, inception_5b_3_3, inception_5b_5_5, inception_5b_pool_1_1], axis=3, mode='concat')
-
 pool5_7_7 = avg_pool_2d(inception_5b_output, kernel_size=7, strides=1)
 pool5_7_7 = dropout(pool5_7_7, 0.4)
-loss = fully_connected(pool5_7_7, 17,activation='softmax')
+
+# fc
+loss = fully_connected(pool5_7_7, 17, activation='softmax')
 network = regression(loss, optimizer='momentum',
                      loss='categorical_crossentropy',
                      learning_rate=0.001)
+
+# to train
 model = tflearn.DNN(network, checkpoint_path='model_googlenet',
                     max_checkpoints=1, tensorboard_verbose=2)
+
 model.fit(X, Y, n_epoch=1000, validation_set=0.1, shuffle=True,
           show_metric=True, batch_size=64, snapshot_step=200,
           snapshot_epoch=False, run_id='googlenet_oxflowers17')
+

--- a/examples/images/network_in_network.py
+++ b/examples/images/network_in_network.py
@@ -24,8 +24,8 @@ from tflearn.layers.estimator import regression
 from tflearn.datasets import cifar10
 (X, Y), (X_test, Y_test) = cifar10.load_data()
 X, Y = shuffle(X, Y)
-Y = to_categorical(Y, 10)
-Y_test = to_categorical(Y_test, 10)
+Y = to_categorical(Y)
+Y_test = to_categorical(Y_test)
 
 # Building 'Network In Network'
 network = input_data(shape=[None, 32, 32, 3])

--- a/examples/images/residual_network_cifar10.py
+++ b/examples/images/residual_network_cifar10.py
@@ -26,8 +26,8 @@ n = 5
 # Data loading
 from tflearn.datasets import cifar10
 (X, Y), (testX, testY) = cifar10.load_data()
-Y = tflearn.data_utils.to_categorical(Y, 10)
-testY = tflearn.data_utils.to_categorical(testY, 10)
+Y = tflearn.data_utils.to_categorical(Y)
+testY = tflearn.data_utils.to_categorical(testY)
 
 # Real-time data preprocessing
 img_prep = tflearn.ImagePreprocessing()

--- a/examples/images/resnext_cifar10.py
+++ b/examples/images/resnext_cifar10.py
@@ -24,8 +24,8 @@ n = 5
 # Data loading
 from tflearn.datasets import cifar10
 (X, Y), (testX, testY) = cifar10.load_data()
-Y = tflearn.data_utils.to_categorical(Y, 10)
-testY = tflearn.data_utils.to_categorical(testY, 10)
+Y = tflearn.data_utils.to_categorical(Y)
+testY = tflearn.data_utils.to_categorical(testY)
 
 # Real-time data preprocessing
 img_prep = tflearn.ImagePreprocessing()

--- a/examples/nlp/bidirectional_lstm.py
+++ b/examples/nlp/bidirectional_lstm.py
@@ -38,8 +38,8 @@ testX, testY = test
 trainX = pad_sequences(trainX, maxlen=200, value=0.)
 testX = pad_sequences(testX, maxlen=200, value=0.)
 # Converting labels to binary vectors
-trainY = to_categorical(trainY, nb_classes=2)
-testY = to_categorical(testY, nb_classes=2)
+trainY = to_categorical(trainY)
+testY = to_categorical(testY)
 
 # Network building
 net = input_data(shape=[None, 200])

--- a/examples/nlp/cnn_sentence_classification.py
+++ b/examples/nlp/cnn_sentence_classification.py
@@ -38,8 +38,8 @@ testX, testY = test
 trainX = pad_sequences(trainX, maxlen=100, value=0.)
 testX = pad_sequences(testX, maxlen=100, value=0.)
 # Converting labels to binary vectors
-trainY = to_categorical(trainY, nb_classes=2)
-testY = to_categorical(testY, nb_classes=2)
+trainY = to_categorical(trainY)
+testY = to_categorical(testY)
 
 # Building convolutional network
 network = input_data(shape=[None, 100], name='input')

--- a/examples/nlp/dynamic_lstm.py
+++ b/examples/nlp/dynamic_lstm.py
@@ -37,8 +37,8 @@ testX, testY = test
 trainX = pad_sequences(trainX, maxlen=100, value=0.)
 testX = pad_sequences(testX, maxlen=100, value=0.)
 # Converting labels to binary vectors
-trainY = to_categorical(trainY, nb_classes=2)
-testY = to_categorical(testY, nb_classes=2)
+trainY = to_categorical(trainY)
+testY = to_categorical(testY)
 
 # Network building
 net = tflearn.input_data([None, 100])

--- a/examples/nlp/lstm.py
+++ b/examples/nlp/lstm.py
@@ -33,8 +33,8 @@ testX, testY = test
 trainX = pad_sequences(trainX, maxlen=100, value=0.)
 testX = pad_sequences(testX, maxlen=100, value=0.)
 # Converting labels to binary vectors
-trainY = to_categorical(trainY, nb_classes=2)
-testY = to_categorical(testY, nb_classes=2)
+trainY = to_categorical(trainY)
+testY = to_categorical(testY)
 
 # Network building
 net = tflearn.input_data([None, 100])

--- a/examples/nlp/seq2seq_example.py
+++ b/examples/nlp/seq2seq_example.py
@@ -14,7 +14,7 @@ import json
 import numpy as np
 import tensorflow as tf
 
-from tensorflow.python.ops import seq2seq
+from tensorflow.contrib.legacy_seq2seq.python.ops import seq2seq
 from tensorflow.python.ops import rnn_cell
 
 #-----------------------------------------------------------------------------

--- a/examples/notebooks/spiral.ipynb
+++ b/examples/notebooks/spiral.ipynb
@@ -116,7 +116,7 @@
     "    gd = tf.train.GradientDescentOptimizer(learning_rate=1.0)\n",
     "    net = tflearn.regression(net, optimizer=gd, loss='categorical_crossentropy')\n",
     "\n",
-    "    Y = to_categorical(y, 3)\n",
+    "    Y = to_categorical(y)\n",
     "    lm = tflearn.DNN(net)\n",
     "    lm.fit(X, Y, show_metric=True, batch_size=len(X), n_epoch=1000, snapshot_epoch=False)"
    ]
@@ -195,7 +195,7 @@
     "    sgd = tflearn.SGD(learning_rate=1.0, lr_decay=0.96, decay_step=500)\n",
     "    net = tflearn.regression(net, optimizer=sgd, loss='categorical_crossentropy')\n",
     "\n",
-    "    Y = to_categorical(y, 3)\n",
+    "    Y = to_categorical(y)\n",
     "    model = tflearn.DNN(net)\n",
     "    model.fit(X, Y, show_metric=True, batch_size=len(X), n_epoch=5000, snapshot_epoch=False)"
    ]

--- a/examples/others/recommender_wide_and_deep.py
+++ b/examples/others/recommender_wide_and_deep.py
@@ -115,7 +115,7 @@ class TFLearnWideAndDeep(object):
         with tf.name_scope("Y"):			# placeholder for target variable (i.e. trainY input)
             Y_in = tf.placeholder(shape=[None, 1], dtype=tf.float32, name="Y")
 
-        with tf.variable_op_scope([wide_inputs], None, "cb_unit", reuse=False) as scope:
+        with tf.variable_scope(None, "cb_unit", [wide_inputs]) as scope:
             central_bias = tflearn.variables.variable('central_bias', shape=[1],
                                                       initializer=tf.constant_initializer(np.random.randn()),
                                                       trainable=True, restore=True)

--- a/tests/test.py
+++ b/tests/test.py
@@ -59,5 +59,35 @@ class TestActivations(unittest.TestCase):
             self.assertAlmostEqual(sess.run(f(x), feed_dict={x:-5}),
                 -1, places=TestActivations.PLACES)
 
+    def test_apply_activation(self):
+        lrelu_02 = lambda x: tflearn.leaky_relu(x, alpha=0.2)
+        x = tf.constant(-0.25, tf.float32)
+
+        with tf.Session() as sess:
+            # Case 1: 'linear'
+            self.assertEqual(
+                sess.run(tflearn.activation(x, 'linear')),
+                -0.25)
+
+            # Case 2: 'relu'
+            self.assertEqual(
+                sess.run(tflearn.activation(x, 'relu')),
+                0)
+
+            # Case 3: 'leaky_relu'
+            self.assertAlmostEqual(
+                sess.run(tflearn.activation(x, 'leaky_relu')),
+                -0.025, places=TestActivations.PLACES)
+
+            # Case 4: 'tanh'
+            self.assertAlmostEqual(
+                sess.run(tflearn.activation(x, 'tanh')),
+                -0.2449, places=TestActivations.PLACES)
+
+            # Case 5: lrelu_02 (callable)
+            self.assertAlmostEqual(
+                sess.run(tflearn.activation(x, lrelu_02)),
+                -0.05, places=TestActivations.PLACES)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tflearn/__init__.py
+++ b/tflearn/__init__.py
@@ -31,7 +31,7 @@ from . import collections # Add TFLearn collections to Tensorflow GraphKeys
 
 # Direct ops inclusion
 from .optimizers import SGD, AdaGrad, Adam, RMSProp, Momentum, Ftrl, AdaDelta, \
-    ProximalAdaGrad
+    ProximalAdaGrad, Nesterov
 from .activations import linear, tanh, sigmoid, softmax, softplus, softsign,\
     relu, relu6, leaky_relu, prelu, elu, crelu, selu
 from .variables import variable, get_all_trainable_variable, \

--- a/tflearn/__init__.py
+++ b/tflearn/__init__.py
@@ -46,7 +46,7 @@ from .layers.conv import conv_2d, max_pool_2d, avg_pool_2d, conv_1d, \
     highway_conv_2d, highway_conv_1d, max_pool_1d, avg_pool_1d, \
     global_avg_pool, residual_block, residual_bottleneck, \
     conv_2d_transpose, upsample_2d, conv_3d, max_pool_3d, avg_pool_3d, \
-    resnext_block, upscore_layer, deconv_2d
+    resnext_block, upscore_layer, deconv_2d, densenet_block
 from .layers.core import input_data, dropout, custom_layer, reshape, \
     flatten, activation, fully_connected, single_unit, highway, \
     one_hot_encoding, time_distributed, multi_target_data

--- a/tflearn/activations.py
+++ b/tflearn/activations.py
@@ -303,4 +303,4 @@ def selu(x):
     """
     alpha = 1.6732632423543772848170429916717
     scale = 1.0507009873554804934193349852946
-    return scale * tf.nn.elu(x, alpha)
+    return scale*tf.where(x>=0.0, x, alpha*tf.nn.elu(x))

--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -7,6 +7,7 @@ import numpy as np
 from PIL import Image
 import pickle
 import csv
+import warnings
 
 """
 Preprocessing provides some useful functions to preprocess data before
@@ -36,6 +37,12 @@ def to_categorical(y, nb_classes):
 
     """
     y = np.asarray(y, dtype='int32')
+    # high dimensional array warning
+    if len(y.shape) > 2:
+        warnings.warn('{}-dimensional array is used as input array.'.format(len(y.shape)), stacklevel=2)
+    # flatten high dimensional array
+    if len(y.shape) > 1:
+        y = y.reshape(-1)
     if not nb_classes:
         nb_classes = np.max(y)+1
     Y = np.zeros((len(y), nb_classes))

--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -8,6 +8,9 @@ from PIL import Image
 import pickle
 import csv
 import warnings
+from urllib.parse import urlparse
+from io import BytesIO
+from urllib import request
 
 """
 Preprocessing provides some useful functions to preprocess data before
@@ -538,7 +541,15 @@ def image_preloader(target_path, image_shape, mode='file', normalize=True,
 
 def load_image(in_image):
     """ Load an image, returns PIL.Image. """
-    img = Image.open(in_image)
+    # if the path appears to be an URL
+    if urlparse(in_image).scheme in ('http', 'https',):
+        # set up the byte stream
+        img_stream = BytesIO(request.urlopen(in_image).read())
+        # and read in as PIL image
+        img = Image.open(img_stream)
+    else:
+        # else use it as local file path
+        img = Image.open(in_image)
     return img
 
 

--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -232,7 +232,7 @@ class VocabularyProcessor(_VocabularyProcessor):
     def fit_transform(self, raw_documents, unused_y=None):
         """ fit_transform.
 
-        Learn the vocabulary dictionary and return indexies of words.
+        Learn the vocabulary dictionary and return indices of words.
 
         Arguments:
             raw_documents: An iterable which yield either str or unicode.

--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -832,6 +832,8 @@ class ImagePreloader(Preloader):
         if grayscale:
             img = convert_color(img, 'L')
         img = pil_to_nparray(img)
+        if grayscale:
+            img = np.reshape(img, img.shape + (1,))
         if normalize:
             img /= 255.
         return img

--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -8,9 +8,14 @@ from PIL import Image
 import pickle
 import csv
 import warnings
-from urllib.parse import urlparse
+try: #py3
+    from urllib.parse import urlparse
+    from urllib import request
+except: #py2
+    from urlparse import urlparse
+    from six.moves.urllib import request
 from io import BytesIO
-from urllib import request
+
 
 """
 Preprocessing provides some useful functions to preprocess data before

--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -33,7 +33,7 @@ _EPSILON = 1e-8
 # =======================
 
 
-def to_categorical(y, nb_classes):
+def to_categorical(y):
     """ to_categorical.
 
     Convert class vector (integers from 0 to nb_classes)
@@ -41,21 +41,8 @@ def to_categorical(y, nb_classes):
 
     Arguments:
         y: `array`. Class vector to convert.
-        nb_classes: `int`. Total number of classes.
-
     """
-    y = np.asarray(y, dtype='int32')
-    # high dimensional array warning
-    if len(y.shape) > 2:
-        warnings.warn('{}-dimensional array is used as input array.'.format(len(y.shape)), stacklevel=2)
-    # flatten high dimensional array
-    if len(y.shape) > 1:
-        y = y.reshape(-1)
-    if not nb_classes:
-        nb_classes = np.max(y)+1
-    Y = np.zeros((len(y), nb_classes))
-    Y[np.arange(len(y)),y] = 1.
-    return Y
+    return (y[:, None] == np.unique(y)).astype(np.float32)
 
 
 # =====================

--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -33,7 +33,7 @@ _EPSILON = 1e-8
 # =======================
 
 
-def to_categorical(y):
+def to_categorical(y, nb_classes=None):
     """ to_categorical.
 
     Convert class vector (integers from 0 to nb_classes)
@@ -41,6 +41,7 @@ def to_categorical(y):
 
     Arguments:
         y: `array`. Class vector to convert.
+        nb_classes: `unused`. Used for older code compatibility.
     """
     return (y[:, None] == np.unique(y)).astype(np.float32)
 

--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -419,7 +419,7 @@ def build_hdf5_image_dataset(target_path, image_shape, output_path='dataset.h5',
             img = resize_image(img, image_shape[0], image_shape[1])
         if grayscale:
             img = convert_color(img, 'L')
-        elif img.mode == 'L':
+        elif img.mode == 'L' or img.mode == 'RGBA':
             img = convert_color(img, 'RGB')
 
         img = pil_to_nparray(img)

--- a/tflearn/datasets/oxflower17.py
+++ b/tflearn/datasets/oxflower17.py
@@ -46,7 +46,7 @@ def maybe_download(filename, source_url, work_directory):
         filepath, _ = urllib.request.urlretrieve(source_url + filename,
                                                  filepath, reporthook)
         statinfo = os.stat(filepath)
-        print(('Succesfully downloaded', filename, statinfo.st_size, 'bytes.'))
+        print('Succesfully downloaded', filename, statinfo.st_size, 'bytes.')
 
         untar(filepath, work_directory)
         build_class_directories(os.path.join(work_directory, 'jpg'))

--- a/tflearn/helpers/trainer.py
+++ b/tflearn/helpers/trainer.py
@@ -237,10 +237,9 @@ class Trainer(object):
 
         original_train_ops = list(self.train_ops)
         # Remove excluded train_ops
-        for t in self.train_ops:
-            if excl_trainops and t in excl_trainops:
-                self.train_ops.remove(t)
-
+        if excl_trainops:
+            self.train_ops = list(filter(lambda a: a not in excl_trainops, self.train_ops))
+	    
         # shuffle is an override for simplicty, it will overrides every
         # training op batch shuffling
         if isinstance(shuffle_all, bool):

--- a/tflearn/layers/__init__.py
+++ b/tflearn/layers/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from .conv import conv_2d, max_pool_2d, avg_pool_2d, conv_1d, \
     max_pool_1d, avg_pool_1d, residual_block, residual_bottleneck, \
     highway_conv_1d, highway_conv_2d, upsample_2d, conv_3d, max_pool_3d, \
-    avg_pool_3d, resnext_block, upscore_layer, deconv_2d
+    avg_pool_3d, resnext_block, upscore_layer, deconv_2d, densenet_block
 from .core import input_data, dropout, custom_layer, reshape, flatten, \
     activation, fully_connected, single_unit, one_hot_encoding, time_distributed, \
     multi_target_data

--- a/tflearn/layers/conv.py
+++ b/tflearn/layers/conv.py
@@ -78,7 +78,7 @@ def conv_2d(incoming, nb_filter, filter_size, strides=1, padding='same',
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
         W_regul = None
-        if regularizer:
+        if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
         W = vs.variable('W', shape=filter_size, regularizer=W_regul,
                         initializer=W_init, trainable=trainable,
@@ -97,7 +97,7 @@ def conv_2d(incoming, nb_filter, filter_size, strides=1, padding='same',
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + name, b)
 
         inference = tf.nn.conv2d(incoming, W, strides, padding)
-        if b: inference = tf.nn.bias_add(inference, b)
+        if b is not None: inference = tf.nn.bias_add(inference, b)
 
         if activation:
             if isinstance(activation, str):
@@ -196,7 +196,7 @@ def conv_2d_transpose(incoming, nb_filter, filter_size, output_shape,
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
         W_regul = None
-        if regularizer:
+        if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
         W = vs.variable('W', shape=filter_size,
                         regularizer=W_regul, initializer=W_init,
@@ -229,7 +229,7 @@ def conv_2d_transpose(incoming, nb_filter, filter_size, output_shape,
         # Reshape tensor so its shape is correct.
         inference.set_shape([None] + output_shape)
 
-        if b: inference = tf.nn.bias_add(inference, b)
+        if b is not None: inference = tf.nn.bias_add(inference, b)
 
         if isinstance(activation, str):
             inference = activations.get(activation)(inference)
@@ -345,7 +345,7 @@ def atrous_conv_2d(incoming, nb_filter, filter_size, rate=1, padding='same',
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
         W_regul = None
-        if regularizer:
+        if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
         W = vs.variable('W', shape=filter_size, regularizer=W_regul,
                         initializer=W_init, trainable=trainable,
@@ -364,7 +364,7 @@ def atrous_conv_2d(incoming, nb_filter, filter_size, rate=1, padding='same',
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + name, b)
 
         inference = tf.nn.atrous_conv2d(incoming, W, rate, padding)
-        if b: inference = tf.nn.bias_add(inference, b)
+        if b is not None: inference = tf.nn.bias_add(inference, b)
 
         if activation:
             if isinstance(activation, str):
@@ -475,7 +475,7 @@ def grouped_conv_2d(incoming, channel_multiplier, filter_size, strides=1,
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
         W_regul = None
-        if regularizer:
+        if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
         W = vs.variable('W', shape=filter_size, regularizer=W_regul,
                         initializer=W_init, trainable=trainable,
@@ -494,7 +494,7 @@ def grouped_conv_2d(incoming, channel_multiplier, filter_size, strides=1,
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + name, b)
 
         inference = tf.nn.depthwise_conv2d(incoming, W, strides, padding)
-        if b: inference = tf.nn.bias_add(inference, b)
+        if b is not None: inference = tf.nn.bias_add(inference, b)
 
         if activation:
             if isinstance(activation, str):
@@ -818,7 +818,7 @@ def conv_1d(incoming, nb_filter, filter_size, strides=1, padding='same',
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
         W_regul = None
-        if regularizer:
+        if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
         W = vs.variable('W', shape=filter_size, regularizer=W_regul,
                         initializer=W_init, trainable=trainable,
@@ -838,7 +838,7 @@ def conv_1d(incoming, nb_filter, filter_size, strides=1, padding='same',
         # Adding dummy dimension to fit with Tensorflow conv2d
         inference = tf.expand_dims(incoming, 2)
         inference = tf.nn.conv2d(inference, W, strides, padding)
-        if b: inference = tf.nn.bias_add(inference, b)
+        if b is not None: inference = tf.nn.bias_add(inference, b)
         inference = tf.squeeze(inference, [2])
 
         if isinstance(activation, str):
@@ -1023,7 +1023,7 @@ def conv_3d(incoming, nb_filter, filter_size, strides=1, padding='same',
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
         W_regul = None
-        if regularizer:
+        if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
         W = vs.variable('W', shape=filter_size, regularizer=W_regul,
                         initializer=W_init, trainable=trainable,
@@ -1041,7 +1041,7 @@ def conv_3d(incoming, nb_filter, filter_size, strides=1, padding='same',
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + name, b)
 
         inference = tf.nn.conv3d(incoming, W, strides, padding)
-        if b: inference = tf.nn.bias_add(inference, b)
+        if b is not None: inference = tf.nn.bias_add(inference, b)
 
         if isinstance(activation, str):
             inference = activations.get(activation)(inference)
@@ -1140,7 +1140,7 @@ def conv_3d_transpose(incoming, nb_filter, filter_size, output_shape,
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
         W_regul = None
-        if regularizer:
+        if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
         W = vs.variable('W', shape=filter_size,
                         regularizer=W_regul, initializer=W_init,
@@ -1173,7 +1173,7 @@ def conv_3d_transpose(incoming, nb_filter, filter_size, output_shape,
         # Reshape tensor so its shape is correct.
         inference.set_shape([None] + output_shape)
 
-        if b: inference = tf.nn.bias_add(inference, b)
+        if b is not None: inference = tf.nn.bias_add(inference, b)
 
         if isinstance(activation, str):
             inference = activations.get(activation)(inference)
@@ -1760,7 +1760,7 @@ def highway_conv_2d(incoming, nb_filter, filter_size, strides=1, padding='same',
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
         W_regul = None
-        if regularizer:
+        if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
         W = vs.variable('W', shape=filter_size, regularizer=W_regul,
                         initializer=W_init, trainable=trainable,
@@ -1887,7 +1887,7 @@ def highway_conv_1d(incoming, nb_filter, filter_size, strides=1, padding='same',
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
         W_regul = None
-        if regularizer:
+        if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
         W = vs.variable('W', shape=filter_size,
                         regularizer=W_regul, initializer=W_init,

--- a/tflearn/layers/conv.py
+++ b/tflearn/layers/conv.py
@@ -1757,10 +1757,10 @@ def densenet_block(incoming, nb_layers, growth, bottleneck=True,
     """
     densenet = incoming
 
-    with tf.variable_scope(scope, default_name=name, values=[incoming],
-                           reuse=reuse) as scope:
+    for i in range(nb_layers):
 
-        for i in range(nb_layers):
+        with tf.variable_scope(scope, default_name=name, values=[incoming],
+                               reuse=reuse) as scope:
 
             # Identity
             conn = densenet

--- a/tflearn/layers/conv.py
+++ b/tflearn/layers/conv.py
@@ -1694,6 +1694,133 @@ def resnext_block(incoming, nb_blocks, out_channels, cardinality,
         return resnext
 
 
+def densenet_block(incoming, nb_layers, growth, bottleneck=True,
+                   downsample=True, downsample_strides=2, activation='relu',
+                   batch_norm=True, dropout=False, dropout_keep_prob=0.5,
+                   weights_init='variance_scaling', regularizer='L2',
+                   weight_decay=0.0001, bias=True, bias_init='zeros',
+                   trainable=True, restore=True, reuse=False, scope=None,
+                   name="DenseNetBlock"):
+    """ DenseNet Block.
+
+    A DenseNet block as described in DenseNet paper.
+
+    Input:
+        4-D Tensor [batch, height, width, in_channels].
+
+    Output:
+        4-D Tensor [batch, new height, new width, out_channels].
+
+    Arguments:
+        incoming: `Tensor`. Incoming 4-D Layer.
+        nb_blocks: `int`. Number of layer blocks.
+        growth: `int`. DenseNet 'growth': The number of convolutional
+            filters of each convolution.
+        bottleneck: `bool`. If True, add a 1x1 convolution before the 3x3 
+            convolution to reduce the number of input features map.
+        downsample: `bool`. If True, apply downsampling using
+            'downsample_strides' for strides.
+        downsample_strides: `int`. The strides to use when downsampling.
+        activation: `str` (name) or `function` (returning a `Tensor`).
+            Activation applied to this layer (see tflearn.activations).
+            Default: 'linear'.
+        batch_norm: `bool`. If True, apply batch normalization.
+        dropout: `bool`. If True, apply dropout. Use 'dropout_keep_prob' to 
+            specify the keep probability.
+        dropout_keep_prob: `float`. Keep probability parameter for dropout.
+        bias: `bool`. If True, a bias is used.
+        weights_init: `str` (name) or `Tensor`. Weights initialization.
+            (see tflearn.initializations) Default: 'uniform_scaling'.
+        bias_init: `str` (name) or `tf.Tensor`. Bias initialization.
+            (see tflearn.initializations) Default: 'zeros'.
+        regularizer: `str` (name) or `Tensor`. Add a regularizer to this
+            layer weights (see tflearn.regularizers). Default: None.
+        weight_decay: `float`. Regularizer decay parameter. Default: 0.001.
+        trainable: `bool`. If True, weights will be trainable.
+        restore: `bool`. If True, this layer weights will be restored when
+            loading a model.
+        reuse: `bool`. If True and 'scope' is provided, this layer variables
+            will be reused (shared).
+        scope: `str`. Define this layer scope (optional). A scope can be
+            used to share variables between layers. Note that scope will
+            override name.
+        name: A name for this layer (optional). Default: 'ResNeXtBlock'.
+
+    References:
+        Densely Connected Convolutional Networks, G. Huang, Z. Liu, 
+        K. Q. Weinberger, L. van der Maaten. 2016.
+
+    Links:
+        [https://arxiv.org/abs/1608.06993]
+        (https://arxiv.org/abs/1608.06993)
+
+    """
+    densenet = incoming
+
+    with tf.variable_scope(scope, default_name=name, values=[incoming],
+                           reuse=reuse) as scope:
+
+        for i in range(nb_layers):
+
+            # Identity
+            conn = densenet
+
+            # 1x1 Conv layer of the bottleneck block
+            if bottleneck:
+                if batch_norm:
+                    densenet = tflearn.batch_normalization(densenet)
+                densenet = tflearn.activation(densenet, activation)
+                densenet = conv_2d(densenet, nb_filter=growth,
+                                   filter_size=1,
+                                   bias=bias,
+                                   weights_init=weights_init,
+                                   bias_init=bias_init,
+                                   regularizer=regularizer,
+                                   weight_decay=weight_decay,
+                                   trainable=trainable,
+                                   restore=restore)
+
+            # 3x3 Conv layer
+            if batch_norm:
+                densenet = tflearn.batch_normalization(densenet)
+            densenet = tflearn.activation(densenet, activation)
+            densenet = conv_2d(densenet, nb_filter=growth,
+                               filter_size=3,
+                               bias=bias,
+                               weights_init=weights_init,
+                               bias_init=bias_init,
+                               regularizer=regularizer,
+                               weight_decay=weight_decay,
+                               trainable=trainable,
+                               restore=restore)
+
+            # Connections
+            densenet = tf.concat([densenet, conn], 3)
+
+        # 1x1 Transition Conv
+        if batch_norm:
+            densenet = tflearn.batch_normalization(densenet)
+        densenet = tflearn.activation(densenet, activation)
+        densenet = conv_2d(densenet, nb_filter=growth,
+                           filter_size=1,
+                           bias=bias,
+                           weights_init=weights_init,
+                           bias_init=bias_init,
+                           regularizer=regularizer,
+                           weight_decay=weight_decay,
+                           trainable=trainable,
+                           restore=restore)
+        if dropout:
+            densenet = tflearn.dropout(densenet, keep_prob=dropout_keep_prob)
+
+        # Downsampling
+        if downsample:
+            densenet = tflearn.avg_pool_2d(densenet, kernel_size=2,
+                                           strides=downsample_strides)
+
+    return densenet
+
+
 def highway_conv_2d(incoming, nb_filter, filter_size, strides=1, padding='same',
                     activation='linear', weights_init='uniform_scaling',
                     bias_init='zeros', regularizer=None, weight_decay=0.001,

--- a/tflearn/layers/conv.py
+++ b/tflearn/layers/conv.py
@@ -1757,10 +1757,10 @@ def densenet_block(incoming, nb_layers, growth, bottleneck=True,
     """
     densenet = incoming
 
-    for i in range(nb_layers):
+    with tf.variable_scope(scope, default_name=name, values=[incoming],
+                           reuse=reuse) as scope:
 
-        with tf.variable_scope(scope, default_name=name, values=[incoming],
-                               reuse=reuse) as scope:
+        for i in range(nb_layers):
 
             # Identity
             conn = densenet

--- a/tflearn/layers/conv.py
+++ b/tflearn/layers/conv.py
@@ -31,7 +31,7 @@ def conv_2d(incoming, nb_filter, filter_size, strides=1, padding='same',
         incoming: `Tensor`. Incoming 4-D Tensor.
         nb_filter: `int`. The number of convolutional filters.
         filter_size: `int` or `list of int`. Size of filters.
-        strides: 'int` or list of `int`. Strides of conv operation.
+        strides: `int` or list of `int`. Strides of conv operation.
             Default: [1 1 1 1].
         padding: `str` from `"same", "valid"`. Padding algo to use.
             Default: 'same'.
@@ -306,7 +306,7 @@ def atrous_conv_2d(incoming, nb_filter, filter_size, rate=1, padding='same',
         incoming: `Tensor`. Incoming 4-D Tensor.
         nb_filter: `int`. The number of convolutional filters.
         filter_size: `int` or `list of int`. Size of filters.
-        rate: 'int`.  A positive int32. The stride with which we sample input
+        rate: `int`.  A positive int32. The stride with which we sample input
             values across the height and width dimensions. Equivalently, the
             rate by which we upsample the filter values by inserting zeros
             across the height and width dimensions. In the literature, the
@@ -440,7 +440,7 @@ def grouped_conv_2d(incoming, channel_multiplier, filter_size, strides=1,
         incoming: `Tensor`. Incoming 4-D Tensor.
         channel_multiplier: `int`. The number of channels to expand to.
         filter_size: `int` or `list of int`. Size of filters.
-        strides: 'int` or list of `int`. Strides of conv operation.
+        strides: `int` or list of `int`. Strides of conv operation.
             Default: [1 1 1 1].
         padding: `str` from `"same", "valid"`. Padding algo to use.
             Default: 'same'.
@@ -1001,7 +1001,7 @@ def conv_3d(incoming, nb_filter, filter_size, strides=1, padding='same',
         incoming: `Tensor`. Incoming 5-D Tensor.
         nb_filter: `int`. The number of convolutional filters.
         filter_size: `int` or `list of int`. Size of filters.
-        strides: 'int` or list of `int`. Strides of conv operation.
+        strides: `int` or list of `int`. Strides of conv operation.
             Default: [1 1 1 1 1]. Must have strides[0] = strides[4] = 1.
         padding: `str` from `"same", "valid"`. Padding algo to use.
             Default: 'same'.

--- a/tflearn/layers/conv.py
+++ b/tflearn/layers/conv.py
@@ -77,6 +77,8 @@ def conv_2d(incoming, nb_filter, filter_size, strides=1, padding='same',
         W_init = weights_init
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
+        elif type(W_init) in [tf.Tensor, np.ndarray, list]:
+            filter_size = None
         W_regul = None
         if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
@@ -89,9 +91,12 @@ def conv_2d(incoming, nb_filter, filter_size, strides=1, padding='same',
 
         b = None
         if bias:
+            b_shape = [nb_filter]
             if isinstance(bias_init, str):
                 bias_init = initializations.get(bias_init)()
-            b = vs.variable('b', shape=nb_filter, initializer=bias_init,
+            elif type(bias_init) in [tf.Tensor, np.ndarray, list]:
+                b_shape = None
+            b = vs.variable('b', shape=b_shape, initializer=bias_init,
                             trainable=trainable, restore=restore)
             # Track per layer variables
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + name, b)
@@ -195,6 +200,8 @@ def conv_2d_transpose(incoming, nb_filter, filter_size, output_shape,
         W_init = weights_init
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
+        elif type(W_init) in [tf.Tensor, np.ndarray, list]:
+            filter_size = None
         W_regul = None
         if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
@@ -206,9 +213,12 @@ def conv_2d_transpose(incoming, nb_filter, filter_size, output_shape,
 
         b = None
         if bias:
+            b_shape = [nb_filter]
             if isinstance(bias_init, str):
                 bias_init = initializations.get(bias_init)()
-            b = vs.variable('b', shape=nb_filter, initializer=bias_init,
+            elif type(bias_init) in [tf.Tensor, np.ndarray, list]:
+                b_shape = None
+            b = vs.variable('b', shape=b_shape, initializer=bias_init,
                             trainable=trainable, restore=restore)
             # Track per layer variables
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + name, b)
@@ -344,6 +354,8 @@ def atrous_conv_2d(incoming, nb_filter, filter_size, rate=1, padding='same',
         W_init = weights_init
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
+        elif type(W_init) in [tf.Tensor, np.ndarray, list]:
+            filter_size = None
         W_regul = None
         if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
@@ -356,9 +368,12 @@ def atrous_conv_2d(incoming, nb_filter, filter_size, rate=1, padding='same',
 
         b = None
         if bias:
+            b_shape = [nb_filter]
             if isinstance(bias_init, str):
                 bias_init = initializations.get(bias_init)()
-            b = vs.variable('b', shape=nb_filter, initializer=bias_init,
+            elif type(bias_init) in [tf.Tensor, np.ndarray, list]:
+                b_shape = None
+            b = vs.variable('b', shape=b_shape, initializer=bias_init,
                             trainable=trainable, restore=restore)
             # Track per layer variables
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + name, b)
@@ -474,6 +489,8 @@ def grouped_conv_2d(incoming, channel_multiplier, filter_size, strides=1,
         W_init = weights_init
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
+        elif type(W_init) in [tf.Tensor, np.ndarray, list]:
+            filter_size = None
         W_regul = None
         if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
@@ -486,9 +503,12 @@ def grouped_conv_2d(incoming, channel_multiplier, filter_size, strides=1,
 
         b = None
         if bias:
+            b_shape = [nb_filter]
             if isinstance(bias_init, str):
                 bias_init = initializations.get(bias_init)()
-            b = vs.variable('b', shape=nb_filter, initializer=bias_init,
+            elif type(bias_init) in [tf.Tensor, np.ndarray, list]:
+                b_shape = None
+            b = vs.variable('b', shape=b_shape, initializer=bias_init,
                             trainable=trainable, restore=restore)
             # Track per layer variables
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + name, b)
@@ -817,6 +837,8 @@ def conv_1d(incoming, nb_filter, filter_size, strides=1, padding='same',
         W_init = weights_init
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
+        elif type(W_init) in [tf.Tensor, np.ndarray, list]:
+            filter_size = None
         W_regul = None
         if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
@@ -828,9 +850,12 @@ def conv_1d(incoming, nb_filter, filter_size, strides=1, padding='same',
 
         b = None
         if bias:
+            b_shape = [nb_filter]
             if isinstance(bias_init, str):
                 bias_init = initializations.get(bias_init)()
-            b = vs.variable('b', shape=nb_filter, initializer=bias_init,
+            elif type(bias_init) in [tf.Tensor, np.ndarray, list]:
+                b_shape = None
+            b = vs.variable('b', shape=b_shape, initializer=bias_init,
                             trainable=trainable, restore=restore)
             # Track per layer variables
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + name, b)
@@ -1022,6 +1047,8 @@ def conv_3d(incoming, nb_filter, filter_size, strides=1, padding='same',
         W_init = weights_init
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
+        elif type(W_init) in [tf.Tensor, np.ndarray, list]:
+            filter_size = None
         W_regul = None
         if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
@@ -1033,9 +1060,12 @@ def conv_3d(incoming, nb_filter, filter_size, strides=1, padding='same',
 
         b = None
         if bias:
+            b_shape = [nb_filter]
             if isinstance(bias_init, str):
                 bias_init = initializations.get(bias_init)()
-            b = vs.variable('b', shape=nb_filter, initializer=bias_init,
+            elif type(bias_init) in [tf.Tensor, np.ndarray, list]:
+                b_shape = None
+            b = vs.variable('b', shape=b_shape, initializer=bias_init,
                             trainable=trainable, restore=restore)
             # Track per layer variables
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + name, b)
@@ -1139,6 +1169,8 @@ def conv_3d_transpose(incoming, nb_filter, filter_size, output_shape,
         W_init = weights_init
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
+        elif type(W_init) in [tf.Tensor, np.ndarray, list]:
+            filter_size = None
         W_regul = None
         if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
@@ -1150,9 +1182,12 @@ def conv_3d_transpose(incoming, nb_filter, filter_size, output_shape,
 
         b = None
         if bias:
+            b_shape = [nb_filter]
             if isinstance(bias_init, str):
                 bias_init = initializations.get(bias_init)()
-            b = vs.variable('b', shape=nb_filter, initializer=bias_init,
+            elif type(bias_init) in [tf.Tensor, np.ndarray, list]:
+                b_shape = None
+            b = vs.variable('b', shape=b_shape, initializer=bias_init,
                             trainable=trainable, restore=restore)
             # Track per layer variables
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + name, b)
@@ -2013,6 +2048,8 @@ def highway_conv_1d(incoming, nb_filter, filter_size, strides=1, padding='same',
         W_init = weights_init
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
+        elif type(W_init) in [tf.Tensor, np.ndarray, list]:
+            filter_size = None
         W_regul = None
         if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)

--- a/tflearn/layers/core.py
+++ b/tflearn/layers/core.py
@@ -338,7 +338,7 @@ def activation(incoming, activation='linear', name='activation'):
 
     if isinstance(activation, str):
         x = activations.get(activation)(incoming)
-    elif hasattr(incoming, '__call__'):
+    elif hasattr(activation, '__call__'):
         x = activation(incoming)
     else:
         raise ValueError('Unknown activation type.')

--- a/tflearn/layers/core.py
+++ b/tflearn/layers/core.py
@@ -147,21 +147,29 @@ def fully_connected(incoming, n_units, activation='linear', bias=True,
         name = scope.name
 
         W_init = weights_init
+        filter_size = [n_inputs, n_units]
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
+        elif type(W_init) in [tf.Tensor, np.ndarray, list]:
+            filter_size = None
         W_regul = None
         if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
-        W = va.variable('W', shape=[n_inputs, n_units], regularizer=W_regul,
+        W = va.variable('W', shape=filter_size, regularizer=W_regul,
                         initializer=W_init, trainable=trainable,
                         restore=restore)
         tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + name, W)
 
         b = None
         if bias:
+            b_shape = [n_units]
             if isinstance(bias_init, str):
                 bias_init = initializations.get(bias_init)()
-            b = va.variable('b', shape=[n_units], initializer=bias_init,
+            elif type(bias_init) in [tf.Tensor, np.ndarray, list]:
+                b_shape = None
+            if isinstance(bias_init, str):
+                bias_init = initializations.get(bias_init)()
+            b = va.variable('b', shape=b_shape, initializer=bias_init,
                             trainable=trainable, restore=restore)
             tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + name, b)
 

--- a/tflearn/layers/core.py
+++ b/tflearn/layers/core.py
@@ -150,7 +150,7 @@ def fully_connected(incoming, n_units, activation='linear', bias=True,
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
         W_regul = None
-        if regularizer:
+        if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
         W = va.variable('W', shape=[n_inputs, n_units], regularizer=W_regul,
                         initializer=W_init, trainable=trainable,
@@ -171,7 +171,7 @@ def fully_connected(incoming, n_units, activation='linear', bias=True,
             inference = tf.reshape(inference, [-1, n_inputs])
 
         inference = tf.matmul(inference, W)
-        if b: inference = tf.nn.bias_add(inference, b)
+        if b is not None: inference = tf.nn.bias_add(inference, b)
         if activation:
             if isinstance(activation, str):
                 inference = activations.get(activation)(inference)
@@ -407,7 +407,7 @@ def single_unit(incoming, activation='linear', bias=True, trainable=True,
             inference = tf.reshape(inference, [-1])
 
         inference = tf.multiply(inference, W)
-        if b: inference = tf.add(inference, b)
+        if b is not None: inference = tf.add(inference, b)
 
         if isinstance(activation, str):
             inference = activations.get(activation)(inference)
@@ -494,7 +494,7 @@ def highway(incoming, n_units, activation='linear', transform_dropout=None,
         if isinstance(weights_init, str):
             W_init = initializations.get(weights_init)()
         W_regul = None
-        if regularizer:
+        if regularizer is not None:
             W_regul = lambda x: losses.get(regularizer)(x, weight_decay)
         W = va.variable('W', shape=[n_inputs, n_units], regularizer=W_regul,
                         initializer=W_init, trainable=trainable,

--- a/tflearn/layers/normalization.py
+++ b/tflearn/layers/normalization.py
@@ -177,7 +177,7 @@ def l2_normalize(incoming, dim, epsilon=1e-12, name="l2_normalize"):
       A `Tensor` with the same shape as `x`.
     """
     with tf.name_scope(name) as name:
-        x = tf.ops.convert_to_tensor(incoming, name="x")
+        x = tf.convert_to_tensor(incoming, name="x")
         square_sum = tf.reduce_sum(tf.square(x), [dim], keep_dims=True)
         x_inv_norm = tf.rsqrt(tf.maximum(square_sum, epsilon))
 

--- a/tflearn/layers/recurrent.py
+++ b/tflearn/layers/recurrent.py
@@ -6,7 +6,7 @@ import numpy as np
 import tensorflow as tf
 from tensorflow.python.ops import array_ops
 try:
-    from tensorflow.python.ops.rnn import rnn_cell_impl as _rnn_cell, dynamic_rnn as _drnn, static_rnn as _rnn, bidirectional_dynamic_rnn as _brnn
+    from tensorflow.python.ops.rnn import rnn_cell_impl as _rnn_cell, dynamic_rnn as _drnn, static_rnn as _rnn, static_bidirectional_rnn as _brnn
     core_rnn_cell = _rnn_cell
 except:
     # Fix for TF 1.1.0 and under

--- a/tflearn/objectives.py
+++ b/tflearn/objectives.py
@@ -256,3 +256,24 @@ def weak_cross_entropy_2d(y_pred, y_true, num_classes=None, epsilon=0.0001,
                                             name="xentropy_mean")
 
     return cross_entropy_mean
+
+def contrastive_loss(y_pred, y_true, margin = 1.0):
+    """ Contrastive Loss.
+    
+        Computes the constrative loss between y_pred (logits) and
+        y_true (labels).
+
+        http://yann.lecun.com/exdb/publis/pdf/chopra-05.pdf
+        Sumit Chopra, Raia Hadsell and Yann LeCun (2005).
+        Learning a Similarity Metric Discriminatively, with Application to Face Verification.
+
+        Arguments:
+            y_pred: `Tensor`. Predicted values.
+            y_true: `Tensor`. Targets (labels).
+            margin: . A self-set parameters that indicate the distance between the expected different identity features. Defaults 1.
+    """
+
+    with tf.name_scope("ContrastiveLoss"):
+        dis1 = y_true * tf.square(y_pred)
+        dis2 = (1 - y_true) * tf.square(tf.maximum((margin - y_pred), 0))
+        return tf.reduce_sum(dis1 +dis2) / 2.

--- a/tflearn/optimizers.py
+++ b/tflearn/optimizers.py
@@ -384,7 +384,7 @@ class Ftrl(Optimizer):
             Only positive values are allowed.
         l1_regularization_strength: `float`. Must be less or equal to zero.
         l2_regularization_strength: `float`. Must be less or equal to zero.
-        use_locking: bool`. If True use locks for update operation.
+        use_locking: `bool`. If True use locks for update operation.
         name: `str`. Optional name prefix for the operations created when
             applying gradients. Defaults to "Ftrl".
 

--- a/tflearn/summaries.py
+++ b/tflearn/summaries.py
@@ -179,6 +179,11 @@ def get_value_from_summary_string(tag, summary_str):
         `Exception` if tag not found.
 
     """
+
+    # Compatibility hotfix for the seq2seq example
+    if tag == u'acc:0/':
+        tag = u'acc_0/'
+
     # Fix for TF 0.12
     if tag[-1] == '/':
         tag = tag[:-1]


### PR DESCRIPTION
I think it has a mistake in this function: 
When I test the codes below from the Quickstart from tflearn :
//---------------------split line --------------------------------
import numpy as np
import tflearn
# Download the Titanic dataset
from tflearn.datasets import titanic
titanic.download_dataset('titanic_dataset.csv')
# Load CSV file, indicate that the first column represents labels
from tflearn.data_utils import load_csv
data, labels = load_csv('titanic_dataset.csv', target_column=0,
                        categorical_labels=True, n_classes=2)
//---------------------split line --------------------------------
the python IDE shows me the error message:
    return (y[:, None] == np.unique(y)).astype(np.float32)
    TypeError: list indices must be integers or slices, not tuple
I checked the source codes of the file "data_utils.py", the error was found in the function "to_categorical",
it should use "y = np.array(y)" before "return (y[:, None] == np.unique(y)).astype(np.float32) " because y should be a array rathen than a list. 
![tflean_data_utils](https://user-images.githubusercontent.com/15982113/32404761-e2410626-c191-11e7-8994-e4bec58b4bd5.png)





