### PR TITLE
Fixes return_seq in recurrent.py to return a 3-D tensor instead of list

### DIFF
--- a/tflearn/layers/recurrent.py
+++ b/tflearn/layers/recurrent.py
@@ -80,12 +80,12 @@ def _rnn_template(incoming, cell, dropout=None, return_seq=False,
 
     if dynamic:
         if return_seq:
-            o = outputs
+            o = tf.stack(outputs, 1)
         else:
             outputs = tf.transpose(tf.stack(outputs), [1, 0, 2])
             o = advanced_indexing_op(outputs, sequence_length)
     else:
-        o = outputs if return_seq else outputs[-1]
+        o = tf.stack(outputs, 1) if return_seq else outputs[-1]
 
     # Track output tensor.
     tf.add_to_collection(tf.GraphKeys.LAYER_TENSOR + '/' + name, o)
@@ -385,12 +385,12 @@ def bidirectional_rnn(incoming, rnncell_fw, rnncell_bw, return_seq=False,
 
     if dynamic:
         if return_seq:
-            o = outputs
+            o = tf.stack(outputs, 1)
         else:
             outputs = tf.transpose(tf.stack(outputs), [1, 0, 2])
             o = advanced_indexing_op(outputs, sequence_length)
     else:
-        o = outputs if return_seq else outputs[-1]
+        o = tf.stack(outputs, 1) if return_seq else outputs[-1]
 
     sfw = states_fw
     sbw = states_bw


### PR DESCRIPTION
According to documentation and examples, recurrent network layers should return a 3-D tensor of shape [samples, timesteps, output dim] if return_seq == True. Currently with the return_seq flag, these layers return a python list of length [timesteps], with each element being a 2-D tensor of shape [samples, output dim]. 

This is a quick fix by stacking the list on dimension 1 when return_seq is set with tf.stack, which leads to the correct output tensor of shape [samples, timesteps, output dim]. 