### PR TITLE
Adding an upscore_layer for 3D. 

### DIFF
--- a/tflearn/layers/conv.py
+++ b/tflearn/layers/conv.py
@@ -497,6 +497,116 @@ def upscore_layer(incoming, num_classes, shape=None, kernel_size=4,
 
     return deconv
 
+def upscore_layer3D(incoming, num_classes, shape=None, kernel_size=4,
+                  strides=2, trainable=True, restore=True,
+                  reuse=False, scope=None, name='Upscore'):
+    """ Upscore.
+
+    This implements the upscore layer as used in
+    (Fully Convolutional Networks)[http://arxiv.org/abs/1411.4038].
+    The upscore layer is initialized as bilinear upsampling filter.
+
+    Input:
+        5-D Tensor [batch, height, width, depth, in_channels].
+
+    Output:
+        5-D Tensor [batch, pooled height, pooled width, pooled depth, in_channels].
+
+    Arguments:
+        incoming: `Tensor`. Incoming 4-D Layer to upsample.
+        num_classes: `int`. Number of output feature maps.
+        shape: `list of int`. Dimension of the output map
+            [batch_size, new height, new width]. For convinience four values
+             are allows [batch_size, new height, new width, X], where X
+             is ignored.
+        kernel_size: 'int` or `list of int`. Upsampling kernel size.
+        strides: 'int` or `list of int`. Strides of conv operation.
+            Default: [1 2 2 2 1].
+        trainable: `bool`. If True, weights will be trainable.
+        restore: `bool`. If True, this layer weights will be restored when
+            loading a model.
+        reuse: `bool`. If True and 'scope' is provided, this layer variables
+            will be reused (shared).
+        scope: `str`. Define this layer scope (optional). A scope can be
+            used to share variables between layers. Note that scope will
+            override name.
+            name: A name for this layer (optional). Default: 'Upscore'.
+
+    Attributes:
+        scope: `Scope`. This layer scope.
+
+    Links:
+        (Fully Convolutional Networks)[http://arxiv.org/abs/1411.4038]
+
+    """
+    input_shape = utils.get_incoming_shape(incoming)
+    assert len(input_shape) == 5, "Incoming Tensor shape must be 5-D"
+
+    strides = utils.autoformat_kernel_3d(strides)
+    filter_size = utils.autoformat_filter_conv3d(kernel_size,
+                                                 num_classes,
+                                                 input_shape[-1])
+
+    # Variable Scope fix for older TF
+    try:
+        vscope = tf.variable_scope(scope, default_name=name, values=[incoming],
+                                   reuse=reuse)
+    except Exception:
+        vscope = tf.variable_op_scope([incoming], scope, name, reuse=reuse)
+
+    with vscope as scope:
+        name = scope.name
+
+        if shape is None:
+            # Compute shape out of Bottom
+            in_shape = tf.shape(incoming)
+
+            h = ((in_shape[1] - 1) * strides[1]) + 1
+            w = ((in_shape[2] - 1) * strides[1]) + 1
+            d = ((in_shape[3] - 1) * strides[1]) + 1
+            new_shape = [in_shape[0], h, w, d, num_classes]
+        else:
+            new_shape = [shape[0], shape[1], shape[2], shape[3], num_classes]
+        output_shape = tf.pack(new_shape)
+
+        def get_deconv_filter(f_shape):
+            """
+            Create filter weights initialized as bilinear upsampling.
+            """
+            width = f_shape[0]
+            heigh = f_shape[0]
+            depth = f_shape[0]
+            f = ceil(width/2.0)
+            c = (2 * f - 1 - f % 2) / (2.0 * f)
+            bilinear = np.zeros([f_shape[0], f_shape[1], fshape[2]])
+            for x in range(width):
+                for y in range(heigh):
+                    for z in range(depth):
+                        value = (1 - abs(x / f - c)) * (1 - abs(y / f - c)) * (1 - abs(z / f - c))
+                        bilinear[x, y, z] = value
+            weights = np.zeros(f_shape)
+            for i in range(f_shape[3]):
+                weights[:, :, :, i, i] = bilinear
+
+            init = tf.constant_initializer(value=weights,
+                                           dtype=tf.float32)
+            W = vs.variable(name="up_filter", initializer=init,
+                            shape=weights.shape, trainable=trainable,
+                            restore=restore)
+            tf.add_to_collection(tf.GraphKeys.LAYER_VARIABLES + '/' + name, W)
+            return W
+
+        weights = get_deconv_filter(filter_size)
+        deconv = tf.nn.conv2d_transpose(incoming, weights, output_shape,
+                                        strides=strides, padding='SAME')
+
+    deconv.scope = scope
+
+    # Track output tensor.
+    tf.add_to_collection(tf.GraphKeys.LAYER_TENSOR + '/' + name, deconv)
+
+    return deconv
+
 
 def conv_1d(incoming, nb_filter, filter_size, strides=1, padding='same',
             activation='linear', bias=True, weights_init='uniform_scaling',


### PR DESCRIPTION
I've added this based on the 2D version. I made a change to the 2D version so the batch number is taken from the input tensor rather than being input by the shape as I needed this for the 3D version.