### PR TITLE
Tensorflow updated the attribute

### DIFF
--- a/tflearn/objectives.py
+++ b/tflearn/objectives.py
@@ -63,7 +63,7 @@ def categorical_crossentropy(y_pred, y_true):
     with tf.name_scope("Crossentropy"):
         y_pred /= tf.reduce_sum(y_pred,
                                 reduction_indices=len(y_pred.get_shape())-1,
-                                keep_dims=True)
+                                keepdims=True)
         # manual computation of crossentropy
         y_pred = tf.clip_by_value(y_pred, tf.cast(_EPSILON, dtype=_FLOATX),
                                   tf.cast(1.-_EPSILON, dtype=_FLOATX))


### PR DESCRIPTION
Hello,

Tensorflow changed to "keepdims",  the parameter for reduce_mean which was keep_dims.

Current version gives this warning:
````
WARNING:tensorflow:From /Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/
site-packages/tflearn/objectives.py:66: calling reduce_sum (from tensorflow.python.ops.math_ops) 
with keep_dims is deprecated and will be removed in a future version.

````


https://www.tensorflow.org/api_docs/python/tf/reduce_mean