### PR TITLE
Fixed init.py for CIFAR-100 dataset

### DIFF
--- a/tflearn/datasets/__init__.py
+++ b/tflearn/datasets/__init__.py
@@ -1,4 +1,5 @@
 from . import cifar10
+from . import cifar100
 from . import imdb
 from . import mnist
 from . import oxflower17


### PR DESCRIPTION
Without this small update to the __init__.py file, you cannot import the cifar100 dataset from the main package. 