### PR TITLE
Speed up importing

### DIFF
--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -180,15 +180,8 @@ def random_sequence_from_textfile(path, seq_maxlen):
     text = open(path).read()
     return random_sequence_from_string(text, seq_maxlen)
 
-try:
-    from tensorflow.contrib.learn.python.learn.preprocessing.text import \
-        VocabularyProcessor as _VocabularyProcessor
-except Exception:
-    _VocabularyProcessor = object
 
-
-# Mirroring TensorFLow `VocabularyProcessor`
-class VocabularyProcessor(_VocabularyProcessor):
+class VocabularyProcessor(object):
     """ Vocabulary Processor.
 
     Maps documents to sequences of word ids.
@@ -209,10 +202,19 @@ class VocabularyProcessor(_VocabularyProcessor):
                  min_frequency=0,
                  vocabulary=None,
                  tokenizer_fn=None):
-        super(VocabularyProcessor, self).__init__(max_document_length,
-                                                  min_frequency,
-                                                  vocabulary,
-                                                  tokenizer_fn)
+        from tensorflow.contrib.learn.python.learn.preprocessing.text import \
+            VocabularyProcessor as _VocabularyProcessor
+        self.__dict__['_vocabulary_processor'] = _VocabularyProcessor(
+            max_document_length,
+            min_frequency,
+            vocabulary,
+            tokenizer_fn)
+
+    def __getattr__(self, key):
+        return getattr(self._vocabulary_processor, key)
+
+    def __setattr__(self, key, value):
+        setattr(self._vocabulary_processor, key, value)
 
     def fit(self, raw_documents, unused_y=None):
         """ fit.
@@ -226,7 +228,7 @@ class VocabularyProcessor(_VocabularyProcessor):
         Returns:
             self
         """
-        return super(VocabularyProcessor, self).fit(raw_documents, unused_y)
+        return self._vocabulary_processor.fit(raw_documents, unused_y)
 
     def fit_transform(self, raw_documents, unused_y=None):
         """ fit_transform.
@@ -240,7 +242,7 @@ class VocabularyProcessor(_VocabularyProcessor):
         Returns:
             X: iterable, [n_samples, max_document_length] Word-id matrix.
         """
-        return super(VocabularyProcessor, self).fit_transform(raw_documents,
+        return self._vocabulary_processor.fit_transform(raw_documents,
                                                               unused_y)
 
     def transform(self, raw_documents):
@@ -257,7 +259,7 @@ class VocabularyProcessor(_VocabularyProcessor):
         Yields:
             X: iterable, [n_samples, max_document_length] Word-id matrix.
         """
-        return super(VocabularyProcessor, self).transform(raw_documents)
+        return self._vocabulary_processor.transform(raw_documents)
 
     def reverse(self, documents):
         """ reverse.
@@ -270,7 +272,7 @@ class VocabularyProcessor(_VocabularyProcessor):
         Returns:
             Iterator over mapped in words documents.
         """
-        return super(VocabularyProcessor, self).reverse(documents)
+        return self._vocabulary_processor.reverse(documents)
 
     def save(self, filename):
         """ save.
@@ -280,7 +282,7 @@ class VocabularyProcessor(_VocabularyProcessor):
         Arguments:
             filename: Path to output file.
         """
-        super(VocabularyProcessor, self).save(filename)
+        return self._vocabulary_processor.save(filename)
 
     @classmethod
     def restore(cls, filename):
@@ -294,7 +296,7 @@ class VocabularyProcessor(_VocabularyProcessor):
         Returns:
             VocabularyProcessor object.
         """
-        return super(VocabularyProcessor, cls).restore(filename)
+        return self._vocabulary_processor.restore(filename)
 
 
 # ===================

--- a/tflearn/initializations.py
+++ b/tflearn/initializations.py
@@ -2,16 +2,7 @@ from __future__ import division, print_function, absolute_import
 
 import math
 import tensorflow as tf
-try:
-    from tensorflow.contrib.layers.python.layers.initializers import \
-        xavier_initializer
-except Exception:
-    xavier_initializer = None
-try:
-    from tensorflow.contrib.layers.python.layers.initializers import \
-        variance_scaling_initializer
-except Exception:
-    variance_scaling_initializer = None
+
 from .utils import get_from_module
 
 
@@ -203,7 +194,10 @@ def xavier(uniform=True, seed=None, dtype=tf.float32):
         [http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf]
         (http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf)
     """
-    if xavier_initializer is None:
+    try:
+        from tensorflow.contrib.layers.python.layers.initializers import \
+            xavier_initializer
+    except ImportError:
         raise NotImplementedError("'xavier_initializer' not supported, "
                                   "please update TensorFlow.")
     return xavier_initializer(uniform=uniform, seed=seed, dtype=dtype)
@@ -259,7 +253,10 @@ def variance_scaling(factor=2.0, mode='FAN_IN', uniform=False, seed=None,
         ValueError: if `dtype` is not a floating point type.
         TypeError: if `mode` is not in ['FAN_IN', 'FAN_OUT', 'FAN_AVG'].
     """
-    if variance_scaling_initializer is None:
+    try:
+        from tensorflow.contrib.layers.python.layers.initializers import \
+            variance_scaling_initializer
+    except ImportError:
         raise NotImplementedError("'variance_scaling_initializer' not "
                                   "supported, please update TensorFlow.")
     return variance_scaling_initializer(factor=factor, mode=mode,

--- a/tflearn/variables.py
+++ b/tflearn/variables.py
@@ -4,7 +4,7 @@ from __future__ import division, print_function, absolute_import
 import tensorflow as tf
 import tflearn
 
-from tensorflow.contrib.framework.python.ops import add_arg_scope as contrib_add_arg_scope
+from tflearn.vendor.arg_scope import add_arg_scope as contrib_add_arg_scope
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import variable_scope
 

--- a/tflearn/vendor/arg_scope.py
+++ b/tflearn/vendor/arg_scope.py
@@ -1,0 +1,216 @@
+# This is a vendored copy of
+# tensorflow/contrib/framework/python/ops/arg_scope.py at 
+# tensorflow@4292085f549afc7d7e9ac5dc517b2bab45c79ad3
+
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Contains the arg_scope used for scoping layers arguments.
+
+  Allows one to define models much more compactly by eliminating boilerplate
+  code. This is accomplished through the use of argument scoping (arg_scope).
+
+  Example of how to use tf.contrib.framework.arg_scope:
+
+  ```
+  from third_party.tensorflow.contrib.layers.python import layers
+
+  arg_scope = tf.contrib.framework.arg_scope
+
+  with arg_scope([layers.conv2d], padding='SAME',
+                 initializer=layers.variance_scaling_initializer(),
+                 regularizer=layers.l2_regularizer(0.05)):
+    net = layers.conv2d(inputs, 64, [11, 11], 4, padding='VALID', scope='conv1')
+    net = layers.conv2d(net, 256, [5, 5], scope='conv2')
+  ```
+  The first call to conv2d will behave as follows:
+    layers.conv2d(inputs, 64, [11, 11], 4, padding='VALID',
+                  initializer=layers.variance_scaling_initializer(),
+                  regularizer=layers.l2_regularizer(0.05), scope='conv1')
+
+  The second call to conv2d will also use the arg_scope's default for padding:
+    layers.conv2d(inputs, 256, [5, 5], padding='SAME',
+                  initializer=layers.variance_scaling_initializer(),
+                  regularizer=layers.l2_regularizer(0.05), scope='conv2')
+
+  Example of how to reuse an arg_scope:
+
+  ```
+  with arg_scope([layers.conv2d], padding='SAME',
+                 initializer=layers.variance_scaling_initializer(),
+                 regularizer=layers.l2_regularizer(0.05)) as sc:
+    net = layers.conv2d(net, 256, [5, 5], scope='conv1')
+    ....
+
+  with arg_scope(sc):
+    net = layers.conv2d(net, 256, [5, 5], scope='conv2')
+  ```
+
+  Example of how to use tf.contrib.framework.add_arg_scope to enable your
+  function to be called within an arg_scope later:
+
+  @tf.contrib.framework.add_arg_scope
+  def conv2d(*args, **kwargs)
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.util import tf_contextlib
+from tensorflow.python.util import tf_decorator
+
+__all__ = [
+    'arg_scope', 'add_arg_scope', 'current_arg_scope', 'has_arg_scope',
+    'arg_scoped_arguments', 'arg_scope_func_key'
+]
+
+_ARGSTACK = [{}]
+
+_DECORATED_OPS = {}
+
+
+def _get_arg_stack():
+  if _ARGSTACK:
+    return _ARGSTACK
+  else:
+    _ARGSTACK.append({})
+    return _ARGSTACK
+
+
+def current_arg_scope():
+  stack = _get_arg_stack()
+  return stack[-1]
+
+
+def arg_scope_func_key(op):
+  return getattr(op, '_key_op', str(op))
+
+
+def _name_op(op):
+  return (op.__module__, op.__name__)
+
+
+def _kwarg_names(func):
+  kwargs_length = len(func.__defaults__) if func.__defaults__ else 0
+  return func.__code__.co_varnames[-kwargs_length:func.__code__.co_argcount]
+
+
+def _add_op(op):
+  key = arg_scope_func_key(op)
+  if key not in _DECORATED_OPS:
+    _DECORATED_OPS[key] = _kwarg_names(op)
+
+
+@tf_contextlib.contextmanager
+def arg_scope(list_ops_or_scope, **kwargs):
+  """Stores the default arguments for the given set of list_ops.
+
+  For usage, please see examples at top of the file.
+
+  Args:
+    list_ops_or_scope: List or tuple of operations to set argument scope for or
+      a dictionary containing the current scope. When list_ops_or_scope is a
+      dict, kwargs must be empty. When list_ops_or_scope is a list or tuple,
+      then every op in it need to be decorated with @add_arg_scope to work.
+    **kwargs: keyword=value that will define the defaults for each op in
+              list_ops. All the ops need to accept the given set of arguments.
+
+  Yields:
+    the current_scope, which is a dictionary of {op: {arg: value}}
+  Raises:
+    TypeError: if list_ops is not a list or a tuple.
+    ValueError: if any op in list_ops has not be decorated with @add_arg_scope.
+  """
+  if isinstance(list_ops_or_scope, dict):
+    # Assumes that list_ops_or_scope is a scope that is being reused.
+    if kwargs:
+      raise ValueError('When attempting to re-use a scope by suppling a'
+                       'dictionary, kwargs must be empty.')
+    current_scope = list_ops_or_scope.copy()
+    try:
+      _get_arg_stack().append(current_scope)
+      yield current_scope
+    finally:
+      _get_arg_stack().pop()
+  else:
+    # Assumes that list_ops_or_scope is a list/tuple of ops with kwargs.
+    if not isinstance(list_ops_or_scope, (list, tuple)):
+      raise TypeError('list_ops_or_scope must either be a list/tuple or reused '
+                      'scope (i.e. dict)')
+    try:
+      current_scope = current_arg_scope().copy()
+      for op in list_ops_or_scope:
+        key = arg_scope_func_key(op)
+        if not has_arg_scope(op):
+          raise ValueError('%s is not decorated with @add_arg_scope',
+                           _name_op(op))
+        if key in current_scope:
+          current_kwargs = current_scope[key].copy()
+          current_kwargs.update(kwargs)
+          current_scope[key] = current_kwargs
+        else:
+          current_scope[key] = kwargs.copy()
+      _get_arg_stack().append(current_scope)
+      yield current_scope
+    finally:
+      _get_arg_stack().pop()
+
+
+def add_arg_scope(func):
+  """Decorates a function with args so it can be used within an arg_scope.
+
+  Args:
+    func: function to decorate.
+
+  Returns:
+    A tuple with the decorated function func_with_args().
+  """
+
+  def func_with_args(*args, **kwargs):
+    current_scope = current_arg_scope()
+    current_args = kwargs
+    key_func = arg_scope_func_key(func)
+    if key_func in current_scope:
+      current_args = current_scope[key_func].copy()
+      current_args.update(kwargs)
+    return func(*args, **current_args)
+
+  _add_op(func)
+  setattr(func_with_args, '_key_op', arg_scope_func_key(func))
+  return tf_decorator.make_decorator(func, func_with_args)
+
+
+def has_arg_scope(func):
+  """Checks whether a func has been decorated with @add_arg_scope or not.
+
+  Args:
+    func: function to check.
+
+  Returns:
+    a boolean.
+  """
+  return arg_scope_func_key(func) in _DECORATED_OPS
+
+
+def arg_scoped_arguments(func):
+  """Returns the list kwargs that arg_scope can set for a func.
+
+  Args:
+    func: function which has been decorated with @add_arg_scope.
+
+  Returns:
+    a list of kwargs names.
+  """
+  assert has_arg_scope(func)
+  return _DECORATED_OPS[arg_scope_func_key(func)]


### PR DESCRIPTION
As discussed in #1069, importing `tflearn` can be very slow due to it importing all of `tensorflow.contrib`.

This PR significantly improves import speed:

```
(master) $ time python -c 'import tflearn'
        5.45 real         4.73 user         0.54 sys
(fast-import) $ time python -c 'import tflearn'
        1.37 real         1.17 user         0.19 sys
```

This is achieved by lazy-loading any `tensorflow.contrib` components that would otherwise be always loaded, with some caveats:

* The first use of `tflearn.initializations.xavier` and `.variance_scaling` will be slow
* `tflearn.data_utils.VocabularyProcessor` no longer inherits from `tensorflow.contrib.learn.python.learn.preprocessing.text.VocabularyProcessor`, which might break some `isinstance()` calls in user code.
* The `tensorflow/contrib/framework/python/ops/arg_scope.py` file is vendored in `tflearn`.

Regarding `VocabularyProcessor`, though – it looks like the class did nothing more than wrap calls to its superclass, so maybe it should be removed altogether with a note to have people use the superclass directly instead (though [it too is deprecated since TensorFlow 1.7.0](https://github.com/tensorflow/tensorflow/commit/c7caa2d87daa37b66811ac99f997ad02acd4ecc8)).

Closes #1069