### PR TITLE
fixed directory mismatch in cifar10 loaddata

### DIFF
--- a/tflearn/datasets/cifar10.py
+++ b/tflearn/datasets/cifar10.py
@@ -66,6 +66,7 @@ def load_batch(fpath):
 
 
 def maybe_download(filename, source_url, work_directory):
+    from shutil import move
     if not os.path.exists(work_directory):
         os.mkdir(work_directory)
     filepath = os.path.join(work_directory, filename)
@@ -75,10 +76,12 @@ def maybe_download(filename, source_url, work_directory):
                                                  filepath, reporthook)
         statinfo = os.stat(filepath)
         print(('Succesfully downloaded', filename, statinfo.st_size, 'bytes.'))
-        untar(filepath)
+
+        untar(filepath,work_directory)
     return filepath
 
-#reporthook from stackoverflow #13881092
+
+# reporthook from stackoverflow #13881092
 def reporthook(blocknum, blocksize, totalsize):
     readsofar = blocknum * blocksize
     if totalsize > 0:
@@ -86,16 +89,24 @@ def reporthook(blocknum, blocksize, totalsize):
         s = "\r%5.1f%% %*d / %d" % (
             percent, len(str(totalsize)), readsofar, totalsize)
         sys.stderr.write(s)
-        if readsofar >= totalsize: # near the end
+        if readsofar >= totalsize:  # near the end
             sys.stderr.write("\n")
-    else: # total size is unknown
+    else:  # total size is unknown
         sys.stderr.write("read %d\n" % (readsofar,))
 
-def untar(fname):
+
+def untar(fname,path=""):
     if (fname.endswith("tar.gz")):
         tar = tarfile.open(fname)
-        tar.extractall(path = '/'.join(fname.split('/')[:-1]))
+        tar.extractall(path=os.path.join(
+            path,
+            '/'.join(fname.split('/')[:-1])
+        ))
         tar.close()
-        print("File Extracted in Current Directory")
+        if path is "":
+            print("File Extracted in Current Directory")
+        else:
+            print("File Extracted in to ".join(path))
     else:
         print("Not a tar.gz file: '%s '" % sys.argv[0])
+

--- a/tflearn/datasets/cifar10.py
+++ b/tflearn/datasets/cifar10.py
@@ -66,7 +66,6 @@ def load_batch(fpath):
 
 
 def maybe_download(filename, source_url, work_directory):
-    from shutil import move
     if not os.path.exists(work_directory):
         os.mkdir(work_directory)
     filepath = os.path.join(work_directory, filename)
@@ -76,7 +75,6 @@ def maybe_download(filename, source_url, work_directory):
                                                  filepath, reporthook)
         statinfo = os.stat(filepath)
         print(('Succesfully downloaded', filename, statinfo.st_size, 'bytes.'))
-
         untar(filepath,work_directory)
     return filepath
 


### PR DESCRIPTION
Ran into an error trying to run:

`from tflearn import cifar10`
`cifar10.load_data('./custom_directory')`

while trying to follow the examples.

the load_data() function expects the cifar10 dataset to be extracted to argument directory, but the untar() function just puts it in current working directory

I added an optional argument to untar to do so. Behavior is unchanged for other calls to it.