### PR TITLE
fix r2_op to match sklearn.metrics.r2_score

### DIFF
--- a/tflearn/metrics.py
+++ b/tflearn/metrics.py
@@ -362,9 +362,9 @@ def r2_op(predictions, targets):
 
     """
     with tf.name_scope('StandardError'):
-        a = tf.reduce_sum(tf.square(predictions))
-        b = tf.reduce_sum(tf.square(targets))
-        return tf.divide(a, b)
+        a = tf.reduce_sum(tf.square(tf.subtract(targets, predictions)))
+        b = tf.reduce_sum(tf.square(tf.subtract(targets, tf.reduce_mean(targets))))
+        return tf.subtract(1.0, tf.divide(a, b))
 
 
 def weighted_r2_op(predictions, targets, inputs):


### PR DESCRIPTION
Someone else already suspected that the r2_op implementation may not be correct: https://github.com/tflearn/tflearn/issues/469

And sure enough, for example here tflearn's r2_op gives a perfect score of 1.0 when it should be -2.0:

```
r2 = tflearn.metrics.r2_op(tf.constant([1, 0.5, 0]), tf.constant([0, 1, 0.5])
with tf.Session() as sess:
    print(sess.run(r2))
```