### PR TITLE
use a separate saver for "best validation accuracy" models

### DIFF
--- a/tflearn/callbacks.py
+++ b/tflearn/callbacks.py
@@ -306,4 +306,4 @@ class ModelSaver(Callback):
     def save_best(self, val_accuracy):
         if self.best_snapshot_path:
             snapshot_path = self.best_snapshot_path + str(val_accuracy)
-            self.save_func(snapshot_path)
+            self.save_func(snapshot_path, use_val_saver=True)


### PR DESCRIPTION
Now the regular training model saver won't delete the "best validation accuracy" models. Previously these snapshots would be included in the `max_checkpoints` count and deleted, leaving the user sometimes without any "best validation accuracy" snapshots.