### PR TITLE
Added Mish Activation

### DIFF
--- a/tflearn/activations.py
+++ b/tflearn/activations.py
@@ -340,3 +340,21 @@ def gelu(x):
     """
     
     return 0.5 * x * (1 + tf.tanh(tf.sqrt(2 / np.pi) * (x + 0.044715 * tf.pow(x, 3))))
+
+
+def mish(x):
+    """Mish Activation Function
+    
+    Mish is self regularized and non-monotonous
+    
+    Arguments
+      x: Input tensor.
+    
+    References:
+      Mish: A Self Regularized Non-Monotonic Neural Activation Function, Misra.D et. al, 2019.
+      
+    Links: 
+        [https://arxiv.org/ftp/arxiv/papers/1908/1908.08681.pdf](https://arxiv.org/ftp/arxiv/papers/1908/1908.08681.pdf)
+    """
+    
+    return x * tf.math.tanh(tf.math.softplus(x))


### PR DESCRIPTION
Mish is a new novel activation function proposed in - [Paper](https://arxiv.org/ftp/arxiv/papers/1908/1908.08681.pdf)
It has shown promising results so far and has been adopted in several packages including: 
1. TensorFlow Addons
2. FastAI-dev
3. SpaCy
4. Thinc
5. DarkNet

All benchmarks, analysis and links to official package implementations can be found in this [repository](https://github.com/digantamisra98/Mish) 

Seems like a good addition considering it has been evaluated against GELU which was recently added to TFLearn and the results show it performs slightly better. 

Post the upcoming release of TFA, Mish can be directly imported from the same.