### PR TITLE
fix: ChainCallback sharing default mutable list

### DIFF
--- a/tflearn/callbacks.py
+++ b/tflearn/callbacks.py
@@ -48,7 +48,9 @@ class Callback(object):
 
 
 class ChainCallback(Callback):
-    def __init__(self, callbacks=[]):
+    def __init__(self, callbacks=None):
+        if callbacks is None:
+            callbacks = []
         self.callbacks = callbacks
 
     def on_train_begin(self, training_state):


### PR DESCRIPTION
In python, the default values of function parameters are instantiated
at function definition time. All calls to that function that use the
default value all point to the same global object. e.g.:

```
def func(x=[]):
   x.append(1)
   print(x)

func() # [1]
func() # [1 , 1]
```

Because of this ChainCallback class potentially all share the same
list of callbacks.

Fix:
The recommended solution is to either set default to None and assign
a new empty object when the variable is None.