### PR TITLE
Implement various distance metrics including Euclidean, Cosine, Manha…

### DIFF
--- a/tflearn/distances.py
+++ b/tflearn/distances.py
@@ -21,3 +21,42 @@ def euclidean(a, b):
 
 def cosine(a, b):
     return 1 - tf.matmul(a, b)
+
+
+def manhattan(a, b):
+    return tf.reduce_sum(tf.abs(a - b), reduction_indices=0)
+
+
+def minkowski(a, b, p):
+    return tf.pow(tf.reduce_sum(tf.pow(tf.abs(a - b), p), 
+                                reduction_indices=0), 1/p)
+
+
+def mahalanobis(a, b, C):
+    diff = a - b
+    return tf.sqrt(tf.matmul(tf.matmul(diff, tf.linalg.inv(C)), diff), 
+                   reduction_indices=0)
+
+
+def hamming(a, b):
+    return tf.reduce_sum(tf.cast(tf.not_equal(a, b), tf.float32))
+
+
+def jaccard(a, b):
+    intersection = tf.reduce_sum(tf.minimum(a, b))
+    union = tf.reduce_sum(tf.maximum(a, b))
+    return 1 - (intersection / union)
+
+
+def canberra(a, b):
+    numerator = tf.abs(a - b)
+    denominator = tf.abs(a) + tf.abs(b)
+    return tf.reduce_sum(numerator / denominator, 
+                         reduction_indices=0)
+
+
+def bray_curtis(a, b):
+    numerator = tf.reduce_sum(tf.abs(a - b))
+    denominator = tf.reduce_sum(tf.abs(a) + tf.abs(b))
+    return numerator / denominator
+    


### PR DESCRIPTION
…ttan, Minkowski, Mahalanobis, Hamming, Jaccard, Canberra, and Bray-Curtis in distances.py

This update introduces a set of essential distance metrics to the `distance.py` module, enhancing its utility for diverse similarity and dissimilarity calculations:

- Euclidean Distance: Ideal for measuring direct point-to-point distances.
- Cosine Similarity: Suitable for assessing vector orientation and similarity.
- Manhattan Distance (L1 Norm): Useful for 'city block' style distance evaluations.
- Minkowski Distance: Offers flexibility with customizable norms.
- Mahalanobis Distance: Accounts for variable correlations in distance computation.
- Hamming Distance: Tailored for comparing binary strings.
- Jaccard Distance: Designed for set similarity analysis.
- Canberra Distance: Takes relative scaling into account for comparisons.
- Bray-Curtis Dissimilarity: Applied in ecological and biological analysis.

These added metrics expand the module's capabilities, making it a versatile resource for a wide range of data analysis and machine learning tasks.