### PR TITLE
Update data_utils.py

### DIFF
--- a/tflearn/data_utils.py
+++ b/tflearn/data_utils.py
@@ -574,7 +574,7 @@ def load_image(in_image):
 
 
 def resize_image(in_image, new_width, new_height, out_image=None,
-                 resize_mode=Image.ANTIALIAS):
+                 resize_mode=Image.LANCZOS):
     """ Resize an image.
 
     Arguments:


### PR DESCRIPTION
"ANTIALIAS was removed in Pillow 10.0.0 (after being deprecated through many previous versions). Now you need to use PIL.Image.LANCZOS or PIL.Image.Resampling.LANCZOS.

(This is the exact same algorithm that ANTIALIAS referred to, you just can no longer access it through the name ANTIALIAS.) Reference https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants"

so i have updated the pillow function which help the users to run the code without error